### PR TITLE
feat - 카카오 로그인 + JWT 토큰 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,11 @@
         "@prisma/client": "^6.2.1",
         "axios": "^1.7.9",
         "body-parser": "^1.20.3",
+        "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "dotenv": "^16.4.7",
         "express": "^4.21.2",
+        "jsonwebtoken": "^9.0.2",
         "mongodb": "^6.12.0"
       },
       "devDependencies": {
@@ -221,6 +223,11 @@
         "node": ">=16.20.1"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -324,6 +331,26 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
@@ -396,6 +423,14 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -770,6 +805,86 @@
       "engines": {
         "node": ">=0.12.0"
       }
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -1158,7 +1273,6 @@
       "version": "7.6.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
       "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       },

--- a/package.json
+++ b/package.json
@@ -16,9 +16,11 @@
     "@prisma/client": "^6.2.1",
     "axios": "^1.7.9",
     "body-parser": "^1.20.3",
+    "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
+    "jsonwebtoken": "^9.0.2",
     "mongodb": "^6.12.0"
   },
   "devDependencies": {

--- a/src/app.js
+++ b/src/app.js
@@ -3,6 +3,7 @@ import cors from 'cors';
 import dotenv from 'dotenv';
 import express from 'express';
 import authRoutes from './routes/authRoutes.js';
+import cookieParser from 'cookie-parser';
 
 dotenv.config({override: true});
 
@@ -11,6 +12,7 @@ const app = express();
 // 미들웨어, 라우트 등등 (Express 애플리케이션 설정)
 app.use(cors());
 app.use(bodyParser.json());
+app.use(cookieParser());
 app.use('/auth', authRoutes);
 
 

--- a/src/controllers/jwtControllers.js
+++ b/src/controllers/jwtControllers.js
@@ -1,0 +1,47 @@
+import jwt from 'jsonwebtoken';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+// JWT 액세스 토큰 생성
+export const generateAccessToken = (user) => {
+  return jwt.sign(
+    { userId: user.id, email: user.email, iat: Math.floor(Date.now() / 1000) },
+    process.env.JWT_SECRET,
+    { expiresIn: process.env.JWT_ACCESS_EXPIRATION } // 액세스 토큰 만료 시간 (1시간)
+  );
+};
+
+// JWT 리프래쉬 토큰 생성
+export const generateRefreshToken = (user) => {
+  return jwt.sign({ userId: user.id, email: user.email }, process.env.JWT_REFRESH_SECRET, {
+    expiresIn: process.env.JWT_REFRESH_EXPIRATION  // 리프래쉬 토큰 만료 시간 (7일)
+  });
+};
+
+
+// JWT 액세스 토큰 갱신
+export const refreshAccessToken = async (req) => {
+  const refreshToken = req.cookies.refreshToken;
+  console.log(refreshToken);
+  if (!refreshToken) {
+    throw new Error('Refresh Token이 필요합니다.');
+  }
+
+  try {
+    const decoded = jwt.verify(refreshToken, process.env.JWT_REFRESH_SECRET);
+    const user = await prisma.user.findUnique({
+      where: { id: decoded.userId },
+    });
+
+    if (!user) {
+      throw new Error('사용자를 찾을 수 없습니다.');
+    }
+
+    // 새로운 Access Token 발급
+    const newAccessToken = generateAccessToken(user);
+    return newAccessToken;
+  } catch (err) {
+    throw new Error('유효하지 않은 Refresh Token입니다.');
+  }
+};

--- a/src/middlewares/jwtMiddlewares.js
+++ b/src/middlewares/jwtMiddlewares.js
@@ -1,0 +1,55 @@
+import jwt from 'jsonwebtoken';
+import { PrismaClient } from '@prisma/client';
+import { refreshAccessToken } from '../controllers/jwtControllers.js';
+
+const prisma = new PrismaClient();
+
+export const jwtMiddleware = async (req, res, next) => {
+  const token = req.headers.authorization?.split(' ')[1];
+
+  if (!token) {
+    return res.status(401).json({ message: 'Access Token이 필요합니다.' });
+  }
+
+  try {
+    // Access Token 검증
+    const decoded = jwt.verify(token, process.env.JWT_SECRET);
+    
+    // 데이터베이스에서 사용자 확인인
+    const user = await prisma.user.findUnique({
+      where: { id: decoded.userId },
+    });
+
+    if (!user) {
+      return res.status(401).json({ message: '사용자를 찾을 수 없습니다.' });
+    }
+
+    // 사용자 정보를 요청 객체에 추가
+    req.user = { userId: user.id, email: user.email };
+    next(); // 다음 미들웨어로 전달
+  } catch (err) {
+    if (err.name === 'TokenExpiredError') {
+      // Access Token이 만료된 경우, Refresh Token을 사용하여 갱신
+      try {
+        const newAccessToken = await refreshAccessToken(req);
+        // 새 액세스 토큰을 헤더에 설정하고 사용자 정보를 유지합니다.
+        req.headers.authorization = `Bearer ${newAccessToken}`;
+        
+        // 새 액세스 토큰으로 디코딩하여 사용자 정보를 가져옵니다.
+        const decoded = jwt.verify(newAccessToken, process.env.JWT_SECRET);
+        req.user = decoded;
+
+        // 프로필 접근 시 사용자 정보를 포함하여 응답합니다.
+        res.status(200).json({
+          message: '프로필 접근 성공',
+          user: req.user
+        });
+      } catch (refreshErr) {
+        return res.status(403).json({ message: '새로운 Access Token 발급 실패' });
+      }
+    } else {
+      return res.status(401).json({ message: '유효하지 않은 Access Token입니다.' });
+    }
+  }
+};
+

--- a/src/routes/authRoutes.js
+++ b/src/routes/authRoutes.js
@@ -1,5 +1,6 @@
 import express from 'express';
 import { redirectToKakaoLogin, handleKakaoCallback, handleKakaoUser, kakaoLogin } from '../controllers/authControllers.js';
+import { jwtMiddleware } from '../middlewares/jwtMiddlewares.js';
 const router = express.Router();
 
 
@@ -8,5 +9,13 @@ router.get('/kakao/callback', handleKakaoCallback); // 카카오에서 인가 �
 
 router.post('/kakao-login', kakaoLogin); // 카카오 액세스 토큰 요청
 router.post('/kakao-login/user', handleKakaoUser); // 카카오 사용자 정보 처리
+
+// jwtMiddleware 테스트용
+router.get('/profile', jwtMiddleware, (req, res) => {
+  res.json({
+    message: '프로필 조회 성공',
+    user: req.user, // jwtMiddleware에서 설정한 사용자 정보
+  });
+});
 
 export default router;


### PR DESCRIPTION
1. 기존 POST http://localhost:3000/auth/kakao-login/user랑 받아온 카카오 액세스 토큰을 통해 유저 로그인을 하면, 로그인한 사용자의 정보를 받아오는 것에서, JWT 액세스 토큰과 쿠키에 리프래시 토큰 발급 받도록 구현 => (response에 사용자 정보랑 JWT 액세스 토큰, 쿠키에 리프래쉬 토큰)

2. .env파일에서 JWT 관련 설정으로 아래 사항 추가
JWT_SECRET=7909b12f13842de0e4f3cc4df1f3ae95ca430fd3964b51fa52cf6e4181a10a23625b5e9188d8618747422482a7472651a139a49df7e2dabfad0e0cb6c2684080
JWT_REFRESH_SECRET=09f124822eecd6ec3e0275734e83a2c1d025a8ac60248f3dbc3e25bd9fb58c531614126cbc7717f9642bbf65228113602470e71b435caa5c7a536ebaa1e83e3
JWT_ACCESS_EXPIRATION=1h
JWT_REFRESH_EXPIRATION=7d

4. app.js에서 쿠키 사용하기 위한 cookie-parser 추가

5. jwtMiddleware에 jwt토큰 인증 미들웨어 생성 => 추후 개발하는 기능의 라우터에 router.use(jwtMiddleware); 하면 자동으로 인증 미들웨어 적용 (jwt 토큰)
Ex: (테스트용 라우트)
GET http://localhost:3000/auth/profile  
Authorization: Bearer (액세스 토큰)

(여기서 액세스 토큰이 만료시 자동으로 쿠키에 저장된 리프래시 토큰을 통해 액세스 토큰 재발급 후 인증 후 해당 라우트 사용가능하도록 통과)

