### PR TITLE
re 개발환경 분리 (conflict 해결)

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,3 @@
+NODE_ENV=development
+KAKAO_CLIENT_ID=7c2e8690981a28b382cb26cc126dd6d0
+REDIRECT_URI=http://localhost:3000/oauth/callback

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,3 @@
+NODE_ENV=production
+KAKAO_CLIENT_ID=7c2e8690981a28b382cb26cc126dd6d0
+REDIRECT_URI=https://codeit-momentum.vercel.app/auth/kakao/callback

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "mongodb": "^6.12.0"
       },
       "devDependencies": {
+        "cross-env": "^7.0.3",
         "nodemon": "^3.1.9",
         "prisma": "^6.2.1"
       }
@@ -366,6 +367,38 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/debug": {
@@ -806,6 +839,12 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
     "node_modules/jsonwebtoken": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
@@ -1130,6 +1169,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
@@ -1334,6 +1382,27 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/side-channel": {
       "version": "1.1.0",
@@ -1543,6 +1612,21 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "nodemon src/server.js",
-    "start": "node src/server.js"
+    "start:dev": "cross-env NODE_ENV=development node src/app.js",
+    "start:prod": "cross-env NODE_ENV=production node src/app.js"
   },
   "keywords": [],
   "author": "",
@@ -24,6 +25,7 @@
     "mongodb": "^6.12.0"
   },
   "devDependencies": {
+    "cross-env": "^7.0.3",
     "nodemon": "^3.1.9",
     "prisma": "^6.2.1"
   }

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,2 +1,2 @@
-.env
+.env*
 package-lock.json

--- a/src/app.js
+++ b/src/app.js
@@ -1,9 +1,10 @@
 import bodyParser from 'body-parser';
+import cookieParser from 'cookie-parser';
 import cors from 'cors';
 import dotenv from 'dotenv';
+import 'dotenv-flow/config';
 import express from 'express';
 import authRoutes from './routes/authRoutes.js';
-import cookieParser from 'cookie-parser';
 
 dotenv.config({override: true});
 

--- a/src/server.js
+++ b/src/server.js
@@ -1,8 +1,8 @@
-import app from './app.js';
 import http from 'http';
+import app from './app.js';
 
 const PORT = process.env.PORT || 3000;
-
+const ENV = process.env.NODE_ENV || 'development';
 const server = http.createServer(app);
 
 server.listen(PORT, () => {


### PR DESCRIPTION
수정 내역
개발 환경과 배포 환경 구분을 위한 dotenv 설정 변경
모든 환경(window, macos, linux)에서 가능하도록 cross-env 사용
server.js 수정
필요한 package 설치 package.json 참고

테스트 실행 방법

env파일 두가지 추가(.env.development, .env.production)
1-2. 내용은 보안상의 이유로 내부에서 공유(REDIRECT_URI, CLIENT_ID, NODE_ENV)
npm install 을 통해 package 설치
개발 환경을 실행 npm run start:dev
배포 환경을 실행 npm run start:prod

conflict 해결
git reset --hard main : main으로 강제 덮어씌우기
재구현