### PR TITLE
feat - 회원가입/로그인에 친구 코드 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
         "dotenv-flow": "^4.1.0",
         "express": "^4.21.2",
         "jsonwebtoken": "^9.0.2",
-        "mongodb": "^6.12.0"
+        "mongodb": "^6.12.0",
+        "nvm": "^0.0.4"
       },
       "devDependencies": {
         "cross-env": "^7.0.3",
@@ -1141,6 +1142,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/nvm": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/nvm/-/nvm-0.0.4.tgz",
+      "integrity": "sha512-jvmyELykYcdyd0VCGY0E8Aqe5MngEasVvlPvrcJHbwBMUbVqa72mPdQuPzyTcykEtEx7jDrMY0QA5MoV+8EhgA==",
+      "deprecated": "This is NOT the correct nvm. Visit https://nvm.sh and use the curl command to install it.",
+      "bin": {
+        "nvm": "bin/nvm"
       }
     },
     "node_modules/object-assign": {

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "nodemon src/server.js",
-    "start:dev": "cross-env NODE_ENV=development node src/server.js",
-    "start:prod": "cross-env NODE_ENV=production node src/server.js"
+    "start:dev": "cross-env NODE_ENV=development nodemon src/server.js",
+    "start:prod": "cross-env NODE_ENV=production nodemon src/server.js"
   },
   "keywords": [],
   "author": "",
@@ -23,7 +23,8 @@
     "dotenv-flow": "^4.1.0",
     "express": "^4.21.2",
     "jsonwebtoken": "^9.0.2",
-    "mongodb": "^6.12.0"
+    "mongodb": "^6.12.0",
+    "nvm": "^0.0.4"
   },
   "devDependencies": {
     "cross-env": "^7.0.3",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,8 +13,9 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 model User {
-  id        String    @id @default(auto()) @map("_id") @db.ObjectId
-  email     String    @unique
-  kakaoId   String    @unique
-  createdAt DateTime  @default(now())
+  id          String    @id @default(auto()) @map("_id") @db.ObjectId
+  email       String    @unique
+  kakaoId     String    @unique
+  friendCode  String    @unique
+  createdAt   DateTime  @default(now())
 }


### PR DESCRIPTION
1. package.json에서 기존 npm run start:dev나 npm run start:dev prod시, nodemon 사용하도록 변경
2. prisma파일에 User 모델에 friendCode 속성 추가 (Unique, Not-Nullable)
3. 기존 카카오 사용자 처리 (데이터베이스 저장/조회) + (JWT 토큰 발급)에서 친구코드 발급 추가 (랜덤 대문자 4자리 + 숫자 4자리)