### PR TITLE
feat - 사용자 조회 & 닉네임 수정 & 프로필 사진 수정 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "express": "^4.21.2",
         "jsonwebtoken": "^9.0.2",
         "mongodb": "^6.12.0",
+        "multer": "^1.4.5-lts.1",
         "nvm": "^0.0.4"
       },
       "devDependencies": {
@@ -1668,6 +1669,11 @@
         "node": ">= 8"
       }
     },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw=="
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -1769,6 +1775,22 @@
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -1845,6 +1867,20 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
+    "node_modules/concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "engines": [
+        "node >= 0.8"
+      ],
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -1896,6 +1932,11 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "node_modules/cors": {
       "version": "2.8.5",
@@ -2411,6 +2452,11 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2576,6 +2622,25 @@
         "node": "*"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
     "node_modules/mongodb": {
       "version": "6.12.0",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.12.0.tgz",
@@ -2634,6 +2699,23 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "node_modules/multer": {
+      "version": "1.4.5-lts.1",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.5-lts.1.tgz",
+      "integrity": "sha512-ywPWvcDMeH+z9gQq5qYHCCy+ethsk4goepZ45GLD63fOu0YcNecQxi64nDs3qluZB+murG3/D4dJ7+dGctcCQQ==",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.0.0",
+        "concat-stream": "^1.5.2",
+        "mkdirp": "^0.5.4",
+        "object-assign": "^4.1.1",
+        "type-is": "^1.6.4",
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
@@ -2795,6 +2877,11 @@
         "fsevents": "2.3.3"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -2861,6 +2948,25 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
@@ -3081,6 +3187,27 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
     "node_modules/strnum": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
@@ -3155,6 +3282,11 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
+    },
     "node_modules/undefsafe": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
@@ -3168,6 +3300,11 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
@@ -3230,6 +3367,14 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "engines": {
+        "node": ">=0.4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "express": "^4.21.2",
     "jsonwebtoken": "^9.0.2",
     "mongodb": "^6.12.0",
+    "multer": "^1.4.5-lts.1",
     "nvm": "^0.0.4"
   },
   "devDependencies": {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,4 +20,5 @@ model User {
   profileImageUrl String?
   friendCode      String    @unique
   createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @default(now())
 }

--- a/src/app.js
+++ b/src/app.js
@@ -5,6 +5,7 @@ import dotenv from 'dotenv';
 import 'dotenv-flow/config';
 import express from 'express';
 import authRoutes from './routes/authRoutes.js';
+import userRoutes from './routes/userRoutes.js';
 
 dotenv.config({override: true});
 
@@ -15,6 +16,7 @@ app.use(cors());
 app.use(bodyParser.json());
 app.use(cookieParser());
 app.use('/auth', authRoutes);
+app.use('/myPage', userRoutes);
 
 console.log('Current Environment:', process.env.NODE_ENV);
 console.log('Redirect URI:', process.env.REDIRECT_URI);

--- a/src/controllers/userControllers.js
+++ b/src/controllers/userControllers.js
@@ -1,0 +1,105 @@
+import { PrismaClient } from '@prisma/client';
+import { s3Client } from '../config/s3config.js';
+import { PutObjectCommand } from '@aws-sdk/client-s3';
+
+const prisma = new PrismaClient();
+
+// 현재 사용자 정보 조회
+export const getCurrentUser = async (req, res) => {
+  try {
+    // 현재 요청한 유저 정보 조회
+    const currentUser = await prisma.user.findUnique({
+      where: { userID: req.user.userID },
+    });
+
+    if (!currentUser) { // 현재 사용자가 없는 경우
+      return res.status(404).json({ message: '현재 사용자를 찾을 수 없습니다.' });
+    }
+
+    // 사용자 정보 반환
+    res.status(200).json({
+      message: '사용자 프로필 접근 성공',
+      user: currentUser 
+    });
+  } catch (err) {
+    console.error('getCurrentUser 오류:', err.message);
+    res.status(500).json({ message: '사용자 정보를 가져오는 데 실패했습니다.' });
+  }
+};
+
+// 사용자 닉네임 업데이트
+export const updateNickname = async (req, res) => {
+  try {
+    const { newNickname } = req.body;
+
+    if (!newNickname) {
+      return res.status(400).json({ message: '새 닉네임이 필요합니다.' });
+    }
+
+    if (newNickname.length > 20) { // 최대 글자 개수 (*논의 필요*)
+      return res.status(400).json({ message: '닉네임은 최대 20자까지 가능합니다.' });
+    }
+
+    // 현재 사용자 업데이트
+    const updatedUser = await prisma.user.update({
+      where: { userID: req.user.userID },
+      data: { nickname: newNickname },
+    });
+
+    res.status(200).json({
+      message: '닉네임이 성공적으로 변경되었습니다.',
+      user: updatedUser,
+    });
+  } catch (err) {
+    console.error('닉네임 변경 오류:', err.message);
+    res.status(500).json({ message: '닉네임 변경 중 오류가 발생했습니다.' });
+  }
+};
+
+// 사용자 프로필 사진 업데이트
+export const updateProfileImage = async (req, res) => {
+  try {
+    if (!req.file) {
+      // 파일이 없는 경우, 기존 프로필 이미지 URL 유지
+      const currentUser = await prisma.user.findUnique({
+        where: { userID: req.user.userID },
+      });
+
+      if (!currentUser) {
+        return res.status(404).json({ message: '사용자를 찾을 수 없습니다.' });
+      }
+
+      return res.status(200).json({
+        message: '이미지를 업로드하지 않아 기존 프로필 이미지를 유지합니다.',
+        user: currentUser,
+      });
+    }
+
+    const bucketName = process.env.AWS_S3_BUCKET_NAME;
+    const key = `profile/custom/${req.user.userID}-${Date.now()}`;
+
+    const command = new PutObjectCommand({
+      Bucket: bucketName,
+      Key: key,
+      Body: req.file.buffer, // Multer는 파일 데이터를 buffer로 제공
+      ContentType: req.file.mimetype, // 파일의 MIME 타입
+    });
+
+    await s3Client.send(command);
+
+    const profileImageUrl = `https://${bucketName}.s3.${process.env.AWS_REGION}.amazonaws.com/${key}`;
+
+    const updatedUser = await prisma.user.update({
+      where: { userID: req.user.userID },
+      data: { profileImageUrl: profileImageUrl },
+    });
+
+    res.status(200).json({
+      message: '프로필 이미지가 성공적으로 업데이트되었습니다.',
+      user: updatedUser,
+    });
+  } catch (err) {
+    console.error('프로필 이미지 업데이트 오류:', err.message);
+    res.status(500).json({ message: '프로필 이미지 업데이트 중 오류가 발생했습니다.' });
+  }
+}

--- a/src/middlewares/jwtMiddlewares.js
+++ b/src/middlewares/jwtMiddlewares.js
@@ -15,7 +15,7 @@ export const jwtMiddleware = async (req, res, next) => {
     // Access Token 검증
     const decoded = jwt.verify(token, process.env.JWT_SECRET);
     
-    // 데이터베이스에서 사용자 확인인
+    // 데이터베이스에서 사용자 확인
     const user = await prisma.user.findUnique({
       where: { id: decoded.userId },
     });
@@ -25,7 +25,14 @@ export const jwtMiddleware = async (req, res, next) => {
     }
 
     // 사용자 정보를 요청 객체에 추가
-    req.user = { userId: user.id, email: user.email };
+    req.user = { 
+      userId: user.id, 
+      userID: user.userID,
+      email: user.email,
+      nickname: user.nickname,
+      profileImageUrl: user.profileImageUrl,
+      friendCode: user.friendCode,
+    };
     next(); // 다음 미들웨어로 전달
   } catch (err) {
     if (err.name === 'TokenExpiredError') {

--- a/src/routes/userRoutes.js
+++ b/src/routes/userRoutes.js
@@ -1,0 +1,18 @@
+import express from 'express';
+import multer from 'multer';
+import { jwtMiddleware } from '../middlewares/jwtMiddlewares.js';
+import { getCurrentUser, updateNickname, updateProfileImage } from '../controllers/userControllers.js';
+
+const router = express.Router();
+const upload = multer(); 
+
+// 인증 미들웨어 적용 (jwt 토큰)
+router.use(jwtMiddleware);
+
+// API 명세서 다 작성하지 않아서 경로명 임의로 정함함
+
+router.get('/profile', getCurrentUser); // 현재 사용자 정보 반환
+router.put('/profile/update-nickname', updateNickname); // 사용자 닉네임 업데이트
+router.put('/profile/update-profileImage', upload.single('profileImage'), updateProfileImage); // 사용자 프로필 이미지 업데이트트
+
+export default router;


### PR DESCRIPTION
*마이페이지 경로는 API 명세서 나오는대로 수정 필요*
1. 마이페이지 관련 컨트롤러, 라우트 생성 (userControllers.js, userRoutes.js)
2. 마이페이지 관련 API => 모두 JWT 토큰 인증 필요 => JWT 토큰으로 사용자 인증 후 진행하도록 인증 미들웨어 적용 router.use(jwtMiddleware); (앞으로 항상 Authorization Bearer {토큰} 필요
3. 현재 사용자 정보 조회 (GET '/mypage/profile') 
GET http://localhost:3000/myPage/profile
Authorization: Bearer 토큰
![image](https://github.com/user-attachments/assets/e12a573c-b5f3-4ae5-a51a-b0fafe4d2568)
4. 현재 사용자 닉네임 변경 (PUT '/myPage/profile/update-nickname')
PUT http://localhost:3000/myPage/profile/update-nickname
Content-Type: application/json
Authorization: Bearer 토큰

{
  "newNickname": "test9525"
}
![image](https://github.com/user-attachments/assets/3f5b2d5c-f88c-420c-bad3-74deee07c12e)
5. 현재 사용자 프로필 이미지 변경 (PUT '/myPage/profile/update-profileImage')
- 프로필 이미지 업로드 X시 기존의 프로필 이미지로 유지
PUT http://localhost:3000/myPage/profile/update-nickname
Content-Type: multipart/form-data
Authorization: Bearer 토큰
"profileImage": (이미지 파일 업로드)
![image](https://github.com/user-attachments/assets/42ee475a-d1df-47be-8a19-240dbe0d6b3f)

6. 기존의 인가 코드를 통한 카카오 로그인 응답 형식 API 명세서에 맞게 수정 (GET '/auth/kakao-login')
![image](https://github.com/user-attachments/assets/77979e03-ef1e-4cb8-984f-0c97deaa4172)

