### PR TITLE
feat - 사용자 친구 목록 조회, 친구 추가 요청, 친구 요청 목록 조회, 친구 요청 수락/거절 구현 & fix - 사용자 친구 목록 조회 수정 & jwt미들웨어 리프래시 토큰 재발급 수정

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,4 +21,44 @@ model User {
   friendCode      String    @unique
   createdAt       DateTime  @default(now())
   updatedAt       DateTime  @default(now())
+
+  FriendRequests  FriendRequest[] @relation("Requester") // 사용자가 보낸 친구 요청들
+  ReceivedRequests FriendRequest[] @relation("Receiver") // 사용자가 받은 친구 요청들
+
+  Friends          Friend[]        @relation("UserFriend") // 사용자가 추가한 친구 목록
+  FriendUsers      Friend[]        @relation("FriendUser") // 사용자를 친구로 추가한 사용자 목록
+}
+
+model FriendRequest {
+  id          String    @id @default(auto()) @map("_id") @db.ObjectId
+  requesterID String // 요청자(userID) 참조
+  receiverID  String // 요청 받은 사람(userID) 참조
+  status      FriendRequestStatus @default(PENDING) // 친구 요청 상태
+  createdAt   DateTime  @default(now()) 
+  updatedAt   DateTime  @default(now())
+
+  requester   User      @relation("Requester", fields: [requesterID], references: [userID]) // 요청 보낸 사용자
+  receiver    User      @relation("Receiver", fields: [receiverID], references: [userID]) // 요청 받은 사용자
+
+  @@unique([requesterID, receiverID]) // 동일한 사용자 간의 중복 요청 방지
+}
+
+enum FriendRequestStatus {
+  PENDING // 요청 대기 상태
+  ACCEPTED // 요청 수락 상태
+  DECLINED // 요청 거절 상태
+}
+
+model Friend {
+  id           String    @id @default(auto()) @map("_id") @db.ObjectId
+  userID       String // 사용자(userID) 참조
+  friendUserID String // 친구(userID) 참조
+  isFixed      Boolean   @default(false) // 친구 목록에서 고정 여부
+  fixedAt      DateTime? 
+  createdAt    DateTime  @default(now())
+
+  user         User      @relation("UserFriend", fields: [userID], references: [userID]) // 친구 관계의 주체
+  friendUser   User      @relation("FriendUser", fields: [friendUserID], references: [userID]) // 친구 관계의 대상
+
+  @@unique([userID, friendUserID]) // 동일한 사용자 간 중복 친구 관계 방지
 }

--- a/src/app.js
+++ b/src/app.js
@@ -6,6 +6,8 @@ import 'dotenv-flow/config';
 import express from 'express';
 import authRoutes from './routes/authRoutes.js';
 import userRoutes from './routes/userRoutes.js';
+import friendRoutes from './routes/friendRoutes.js';
+
 
 dotenv.config({override: true});
 
@@ -16,7 +18,8 @@ app.use(cors());
 app.use(bodyParser.json());
 app.use(cookieParser());
 app.use('/auth', authRoutes);
-app.use('/myPage', userRoutes);
+app.use('/api/myPage', userRoutes);
+app.use('/api/friends', friendRoutes);
 
 console.log('Current Environment:', process.env.NODE_ENV);
 console.log('Redirect URI:', process.env.REDIRECT_URI);

--- a/src/controllers/friendControllers.js
+++ b/src/controllers/friendControllers.js
@@ -1,0 +1,131 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+// 사용자 친구 목록 조회
+export const getFriends = async (req, res) => {
+  try {
+    // 친구 목록 조회
+    const friends = await prisma.friend.findMany({
+      where: {
+        OR: [
+          { userID: req.user.userID }, // 사용자가 친구 관계의 주체인 경우
+          { friendUserID: req.user.userID }, // 사용자가 친구 관계의 대상인 경우
+        ],
+      },
+      include: {
+        user: true, // 친구 관계의 주체 정보 포함
+        friendUser: true, // 친구 관계의 대상 정보 포함
+      },
+    });
+
+    // 친구 목록 응답
+    const friendList = friends.map((friend) => {
+      const isCurrentUserPrimary = friend.userID === userId;
+      const friendInfo = isCurrentUserPrimary ? friend.friendUser : friend.user;
+
+      return {
+        userID: friendInfo.userID,
+        nickname: friendInfo.nickname,
+        profileImageUrl: friendInfo.profileImageUrl,
+        isFixed: friend.isFixed,
+        fixedAt: friend.fixedAt,
+        createdAt: friend.createdAt,
+      };
+    });
+
+    res.status(200).json({
+      message: '친구 목록 조회 성공',
+      friends: friendList,
+    });
+  } catch (err) {
+    console.error('친구 목록 조회 오류:', err.message);
+    res.status(500).json({ message: '친구 목록 조회 중 오류가 발생했습니다.' });
+  }
+}
+
+// 사용자 친구 요청 전송
+export const addFriendRequest = async (req, res) => {
+  const { friendCode } = req.body;
+  const requesterID = req.user.userID; // 현재 요청을 보낸 사용자 ID
+
+  // 친구코드가 없는 경우 에러 반환
+  if (!friendCode) {
+    return res.status(400).json({ message: '친구코드가 필요합니다.' });
+  }
+
+  try {
+    // 친구코드로 상대방 ID 조회
+    const receiver = await prisma.user.findUnique({
+      where: { friendCode },
+    });
+
+    // 친구코드가 유효하지 않은 경우
+    if (!receiver) {
+      return res.status(404).json({ message: '존재하지 않는 친구코드 입니다.' });
+    }
+
+    const receiverID = receiver.userID;
+
+    // 자기 자신에게 친구 요청을 보낼 수 없음
+    if (requesterID === receiverID) {
+      return res.status(400).json({ message: '자기 자신에게 친구 요청을 보낼 수 없습니다.' });
+    }
+
+    // 요청자의 정보 조회
+    const requester = await prisma.user.findUnique({
+      where: { userID: requesterID },
+    });
+
+    // 기존 친구 요청 또는 친구 관계 상태 확인
+    const existingRequest = await prisma.friendRequest.findUnique({
+      where: {
+        requesterID_receiverID: {
+          requesterID,
+          receiverID,
+        },
+      },
+    });
+
+    if (existingRequest) {
+      if (existingRequest.status === 'PENDING') {
+        return res.status(409).json({
+          message: '이미 상대방으로부터 친구 요청이 있습니다. 친구 요청 목록을 확인해주세요.',
+        });
+      }
+      if (existingRequest.status === 'ACCEPTED') {
+        return res.status(409).json({ message: '이미 상대방과 친구 관계입니다.' });
+      }
+      if (existingRequest.status === 'REJECTED') {
+        return res.status(409).json({
+          message: '상대방으로부터 친구 요청 거절 당했습니다.',
+        });
+      }
+    }
+
+    // 친구 요청 생성
+    const newFriendRequest = await prisma.friendRequest.create({
+      data: {
+        requesterID,
+        receiverID,
+        status: 'PENDING', // 기본 상태 (승낙 대기)
+      },
+    });
+
+    res.status(201).json({
+      message: '친구 요청 전송 성공',
+      friendRequest: {
+        id: newFriendRequest.id,
+        requesterID: newFriendRequest.requesterID,
+        requesterNickname: requester.nickname, // 요청자 닉네임 (DB 저장 X)
+        receiverID: newFriendRequest.receiverID,
+        receiverNickname: receiver.nickname, // 수신자 닉네임 (DB 저장 X)
+        status: newFriendRequest.status,
+        createdAt: newFriendRequest.createdAt,
+      },
+    });
+  } catch (err) {
+    console.error('친구 요청 전송 오류:', err.message);
+    res.status(500).json({ message: '친구 요청 전송 중 오류가 발생했습니다.' });
+  }
+};

--- a/src/middlewares/jwtMiddlewares.js
+++ b/src/middlewares/jwtMiddlewares.js
@@ -44,13 +44,30 @@ export const jwtMiddleware = async (req, res, next) => {
         
         // 새 액세스 토큰으로 디코딩하여 사용자 정보를 가져옵니다.
         const decoded = jwt.verify(newAccessToken, process.env.JWT_SECRET);
-        req.user = decoded;
-
-        // 프로필 접근 시 사용자 정보를 포함하여 응답합니다.
-        res.status(200).json({
-          message: '프로필 접근 성공',
-          user: req.user
+        // 데이터베이스에서 사용자 확인
+        const user = await prisma.user.findUnique({
+          where: { id: decoded.userId },
         });
+
+        if (!user) {
+          return res.status(401).json({ message: '사용자를 찾을 수 없습니다.' });
+        }
+
+        // 새 Access Token을 요청 객체에 반영
+        req.headers.authorization = `Bearer ${newAccessToken}`;
+        req.user = {
+          userId: user.id,
+          userID: user.userID,
+          email: user.email,
+          nickname: user.nickname,
+          profileImageUrl: user.profileImageUrl,
+          friendCode: user.friendCode,
+        };
+
+        // 새 Access Token을 응답 헤더로 전달
+        res.setHeader('x-access-token', newAccessToken);
+
+        next(); // 다음 미들웨어로 전달
       } catch (refreshErr) {
         return res.status(403).json({ message: '새로운 Access Token 발급 실패' });
       }

--- a/src/routes/friendRoutes.js
+++ b/src/routes/friendRoutes.js
@@ -1,6 +1,6 @@
 import express from 'express';
 import { jwtMiddleware } from '../middlewares/jwtMiddlewares.js';
-import { addFriendRequest, getFriends } from '../controllers/friendControllers.js';
+import { addFriendRequest, getFriendRequests, getFriends, handleFriendRequest } from '../controllers/friendControllers.js';
 
 const router = express.Router();
 
@@ -11,5 +11,7 @@ router.use(jwtMiddleware);
 
 router.get('/', getFriends); // 친구 목록 조회
 router.post('/', addFriendRequest); // 친구 추가
+router.get('/requests', getFriendRequests); // 친구 요청 목록 조회
+router.patch('/requests/:friendRequestID', handleFriendRequest); // 친구 요청 수락/거절
 
 export default router;

--- a/src/routes/friendRoutes.js
+++ b/src/routes/friendRoutes.js
@@ -1,0 +1,15 @@
+import express from 'express';
+import { jwtMiddleware } from '../middlewares/jwtMiddlewares.js';
+import { addFriendRequest, getFriends } from '../controllers/friendControllers.js';
+
+const router = express.Router();
+
+// 인증 미들웨어 적용 (jwt 토큰)
+router.use(jwtMiddleware);
+
+// API 명세서 다 작성하지 않아서 경로명 임의로 정함
+
+router.get('/', getFriends); // 친구 목록 조회
+router.post('/', addFriendRequest); // 친구 추가
+
+export default router;


### PR DESCRIPTION
1. 마이페이지 관련 라우트 '/myPage' 에서 /api/myPage'로 수정
2. prisma에 FriendRequest, Friend 테이블 추가
- npx prisma db push로 적용
3. friendControllers.js, friendRoutes.js 추가 ('/api/friends')
4. 사용자 친구 목록 조회 구현 (GET '/api/friends')
![image](https://github.com/user-attachments/assets/7483cb84-e934-4548-93e5-c0c56c950ee9)
5. 친구 추가 요청 구현 (POST '/api/friends') (friendCode req로 받아서 요청 보냄)
![image](https://github.com/user-attachments/assets/96663963-8edd-4294-8e80-7ee558898f1a)
6. 친구 요청 목록 조회 (GET '/api/friends/requests') (내가 요청한것과, 상대방이 요청 보낸 것 모두 확인 가능) (현재는 Pending인 것만 확인 가능하도록 구현)
![image](https://github.com/user-attachments/assets/5c32bad1-e858-4e82-a8c7-78116494ea60)
7. 사용자 친구 요청 수락/거절 구현 (PATCH '/api/friends/requests/:friendRequestID') (req에 status값으로 ACCEPTED, REJECTED를 받아와서 수락/거절 구현) 수락시 Friend 테이블에 친구관계 생성, 거절시 status만 REJECTED로 변경
![image](https://github.com/user-attachments/assets/8c1dcfe2-9f2b-4e15-8c60-3bcb16822b4d)
