### PR TITLE
fix - 마이페이지 경로 변경 및 현재 사용자의 친구 코드 조회 기능 추가

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -18,7 +18,7 @@ app.use(cors());
 app.use(bodyParser.json());
 app.use(cookieParser());
 app.use('/auth', authRoutes);
-app.use('/api/myPage', userRoutes);
+app.use('/api/users', userRoutes);
 app.use('/api/friends', friendRoutes);
 
 console.log('Current Environment:', process.env.NODE_ENV);

--- a/src/controllers/userControllers.js
+++ b/src/controllers/userControllers.js
@@ -27,6 +27,29 @@ export const getCurrentUser = async (req, res) => {
   }
 };
 
+// 현재 사용자 친구 코드 조회
+export const getUserFriendCode = async (req, res) => {
+  try {
+    // 현재 요청한 유저 정보 조회
+    const currentUser = await prisma.user.findUnique({
+      where: { userID: req.user.userID },
+    });
+
+    if (!currentUser) { // 현재 사용자가 없는 경우
+      return res.status(404).json({ message: '현재 사용자를 찾을 수 없습니다.' });
+    }
+
+    // 사용자 정보 반환
+    res.status(200).json({
+      message: '사용자의 친구 코드 접근 성공',
+      friendCode: currentUser.friendCode 
+    });
+  } catch (err) {
+    console.error('getUserFriendCode 오류:', err.message);
+    res.status(500).json({ message: '사용자의 친구 코드를 가져오는 데 실패했습니다.' });
+  }
+};
+
 // 사용자 닉네임 업데이트
 export const updateNickname = async (req, res) => {
   try {
@@ -44,6 +67,12 @@ export const updateNickname = async (req, res) => {
     const updatedUser = await prisma.user.update({
       where: { userID: req.user.userID },
       data: { nickname: newNickname },
+      select: {
+        userID: true,
+        nickname: true,
+        email: true,
+        profileImageUrl: true,
+      },
     });
 
     res.status(200).json({

--- a/src/routes/userRoutes.js
+++ b/src/routes/userRoutes.js
@@ -1,7 +1,7 @@
 import express from 'express';
 import multer from 'multer';
 import { jwtMiddleware } from '../middlewares/jwtMiddlewares.js';
-import { getCurrentUser, updateNickname, updateProfileImage } from '../controllers/userControllers.js';
+import { getCurrentUser, getUserFriendCode, updateNickname, updateProfileImage } from '../controllers/userControllers.js';
 
 const router = express.Router();
 const upload = multer(); 
@@ -9,10 +9,9 @@ const upload = multer();
 // 인증 미들웨어 적용 (jwt 토큰)
 router.use(jwtMiddleware);
 
-// API 명세서 다 작성하지 않아서 경로명 임의로 정함함
-
-router.get('/profile', getCurrentUser); // 현재 사용자 정보 반환
-router.put('/profile/update-nickname', updateNickname); // 사용자 닉네임 업데이트
-router.put('/profile/update-profileImage', upload.single('profileImage'), updateProfileImage); // 사용자 프로필 이미지 업데이트트
+router.get('/', getCurrentUser); // 현재 사용자 정보 반환
+router.patch('/nickname', updateNickname); // 사용자 닉네임 업데이트
+router.patch('/profileImage', upload.single('profileImage'), updateProfileImage); // 사용자 프로필 이미지 업데이트
+router.get('/friendCode', getUserFriendCode); // 현재 사용자의 친구 코드 반환
 
 export default router;


### PR DESCRIPTION
1. 기존 마이페이지 API 라우트 수정 (API 명세서 바탕으로 수정)
- GET '/api/users' (현재 사용자의 정보 조회)
- PATCH '/api/users/profileImage (현재 사용자의 프로필 이미지 수정) (기존 PUT => PATCH 변경)
- PATCH '/api/users/nickname (현재 사용자의 닉네임 수정) (기존 PUT => PATCH 변경)
- GET '/api/users/friendCode (현재 사용자의 친구 코드 조회 ) (그냥 위의 GET '/api/users' 에서 friendCode도 나오므로 해당 라우트로도 친구 코드 조회 가능)