### PR TITLE
친구 삭제 기능, 친구 노크하기 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "dotenv-flow": "^4.1.0",
         "express": "^4.21.2",
         "jsonwebtoken": "^9.0.2",
+        "moment": "^2.30.1",
         "mongodb": "^6.12.0",
         "multer": "^1.4.5-lts.1",
         "nvm": "^0.0.4"
@@ -2639,6 +2640,14 @@
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/mongodb": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "moment": "^2.30.1",
         "mongodb": "^6.12.0",
         "multer": "^1.4.5-lts.1",
+        "node-cron": "^3.0.3",
         "nvm": "^0.0.4"
       },
       "devDependencies": {
@@ -2732,6 +2733,25 @@
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-cron": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.3.tgz",
+      "integrity": "sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A==",
+      "dependencies": {
+        "uuid": "8.3.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/node-cron/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/nodemon": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "moment": "^2.30.1",
     "mongodb": "^6.12.0",
     "multer": "^1.4.5-lts.1",
+    "node-cron": "^3.0.3",
     "nvm": "^0.0.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "dotenv-flow": "^4.1.0",
     "express": "^4.21.2",
     "jsonwebtoken": "^9.0.2",
+    "moment": "^2.30.1",
     "mongodb": "^6.12.0",
     "multer": "^1.4.5-lts.1",
     "nvm": "^0.0.4"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,6 +27,7 @@ model User {
 
   Friends          Friend[]        @relation("UserFriend") // 사용자가 추가한 친구 목록
   FriendUsers      Friend[]        @relation("FriendUser") // 사용자를 친구로 추가한 사용자 목록
+  feeds            Feed[]          @relation("UserFeeds")
 }
 
 model FriendRequest {
@@ -39,7 +40,6 @@ model FriendRequest {
 
   requester   User      @relation("Requester", fields: [requesterID], references: [userID]) // 요청 보낸 사용자
   receiver    User      @relation("Receiver", fields: [receiverID], references: [userID]) // 요청 받은 사용자
-
   @@unique([requesterID, receiverID]) // 동일한 사용자 간의 중복 요청 방지
 }
 
@@ -61,5 +61,22 @@ model Friend {
   user         User      @relation("UserFriend", fields: [userID], references: [userID]) // 친구 관계의 주체
   friendUser   User      @relation("FriendUser", fields: [friendUserID], references: [userID]) // 친구 관계의 대상
 
-  @@unique([userID, friendUserID]) // 동일한 사용자 간 중복 친구 관계 방지
+  @@unique([userID, friendUserID], name: "userID_friendUserID") // 동일한 사용자 간 중복 친구 관계 방지
 }
+
+model Feed {
+  feedID    String   @id @default(auto()) @map("_id") @db.ObjectId
+  userID    String   // 사용자 ID 참조
+  content   String
+  createdAt DateTime @default(now())
+  user      User     @relation("UserFeeds", fields: [userID], references: [userID])
+}
+
+model FriendFeed {
+  friendFeedId String   @id @default(auto()) @map("_id") @db.ObjectId
+  userId       String   @db.ObjectId // 피드를 보는 사용자 ID
+  feedId       String   @db.ObjectId // 친구의 피드 ID
+  createdAt    DateTime @default(now()) // 연결이 생성된 시각
+
+}
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -54,9 +54,10 @@ model Friend {
   userID       String // 사용자(userID) 참조
   friendUserID String // 친구(userID) 참조
   isFixed      Boolean   @default(false) // 친구 목록에서 고정 여부
+  isKnock      Boolean   @default(false)
   fixedAt      DateTime? 
+  knockedAt    DateTime? 
   createdAt    DateTime  @default(now())
-
   user         User      @relation("UserFriend", fields: [userID], references: [userID]) // 친구 관계의 주체
   friendUser   User      @relation("FriendUser", fields: [friendUserID], references: [userID]) // 친구 관계의 대상
 

--- a/src/controllers/friendControllers.js
+++ b/src/controllers/friendControllers.js
@@ -356,7 +356,11 @@ export const knockFriend = async (req, res) => {
         }
       },
       include: {
-        friendUser: true,
+        friendUser: {
+          include: {
+            feeds: true  // 피드 정보 포함
+          },
+        },
       }
     });
 
@@ -364,7 +368,7 @@ export const knockFriend = async (req, res) => {
       return res.status(404).json({ status: "failed", message: "해당 친구를 찾을 수 없습니다." });
     }
 
-    // 친구가 최근 7일 이내에 피드를 올렸는지 확인
+    // 친구가 최근 7일 이내에 피드를 올렸는지 확인  -> 내부 확인용
     if (friendRelation.friendUser.feeds && friendRelation.friendUser.feeds.some(feed => moment(feed.createdAt).isAfter(moment().subtract(7, 'days')))) {
       return res.status(403).json({ status: "failed", message: "해당 친구는 최근 7일 이내에 피드를 올렸습니다." });
     }

--- a/src/controllers/friendControllers.js
+++ b/src/controllers/friendControllers.js
@@ -292,3 +292,38 @@ export const handleFriendRequest = async (req, res) => {
     res.status(500).json({ message: '친구 요청 처리 중 오류가 발생했습니다.' });
   }
 };
+
+// 친구 삭제
+export const deleteFriend = async (req, res) => {
+  const userID = req.user.userID; // 현재 사용자 ID
+  const { friendUserID } = req.body; // 삭제할 친구의 사용자 ID
+
+  try {
+    const friendRelation = await prisma.friend.findMany({
+      where: {
+        OR: [
+          { userID, friendUserID },
+          { userID: friendUserID, friendUserID: userID },
+        ],
+      },
+    });
+
+    if (friendRelation.length === 0) {
+      return res.status(404).json({ message: '친구 관계가 존재하지 않습니다.' });
+    }
+
+    await prisma.friend.deleteMany({
+      where: {
+        OR: [
+          { userID, friendUserID },
+          { userID: friendUserID, friendUserID: userID },
+        ],
+      },
+    });
+
+    res.status(200).json({ message: '친구 관계를 성공적으로 삭제하였습니다.' });
+  } catch (err) {
+    console.error('친구 삭제 오류:', err.message);
+    res.status(500).json({ message: '친구 삭제 중 오류가 발생했습니다.' });
+  }
+};

--- a/src/controllers/friendControllers.js
+++ b/src/controllers/friendControllers.js
@@ -1,6 +1,7 @@
 import { PrismaClient } from '@prisma/client';
-
+import moment from 'moment';
 const prisma = new PrismaClient();
+
 
 // 사용자 친구 목록 조회
 export const getFriends = async (req, res) => {
@@ -325,5 +326,63 @@ export const deleteFriend = async (req, res) => {
   } catch (err) {
     console.error('친구 삭제 오류:', err.message);
     res.status(500).json({ message: '친구 삭제 중 오류가 발생했습니다.' });
+  }
+};
+
+//친구에게 노크하기
+export const knockFriend = async (req, res) => {
+  const userID = req.user.userID; // 현재 사용자 ID
+  const { friendId } = req.body; // 노크할 친구의 사용자 ID
+
+  try {
+    // 친구 관계 검색
+    const friendRelation = await prisma.friend.findUnique({
+      where: {
+        userID_friendUserID: {
+          userID,
+          friendUserID: friendId
+        }
+      },
+      include: {
+        friendUser: {
+          include: {
+            feed: true // 친구의 피드 정보 포함
+          }
+        }
+      }
+    });
+
+    // 존재하지 않는 친구 ID 검증
+    if (!friendRelation) {
+      return res.status(404).json({ status: "failed", message: "해당 친구를 찾을 수 없습니다." });
+    }
+
+    // 친구가 최근 7일 이내에 피드를 올렸는지 확인
+    const lastWeek = moment().subtract(7, 'days').toDate();
+    if (friendRelation.friendUser.feed.some(feed => moment(feed.createdAt).isSameOrAfter(lastWeek))) {
+      return res.status(403).json({ status: "failed", message: "해당 친구는 최근 7일 이내에 피드를 올렸습니다." });
+    }
+
+    // 주별 노크 제한 검사
+    const now = new Date();
+    const startOfWeek = moment().startOf('isoWeek').toDate();
+    if (friendRelation.knockedAt && moment(friendRelation.knockedAt).isSameOrAfter(startOfWeek)) {
+      return res.status(403).json({ status: "failed", message: "노크는 일주일에 한 번만 가능합니다." });
+    }
+
+    // 노크 상태 업데이트
+    await prisma.friend.update({
+      where: {
+        id: friendRelation.id
+      },
+      data: {
+        knockedAt: now
+      }
+    });
+
+    res.status(200).json({ status: "success", message: "노크 알림이 전송되었습니다." });
+  } catch (err) {
+    console.error('노크 오류:', err.message);
+    res.status(500).json({ status: "error", message: "서버에서 문제가 발생했습니다. 잠시 후 다시 시도해주시길 바랍니다." });
   }
 };

--- a/src/routes/friendRoutes.js
+++ b/src/routes/friendRoutes.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import { addFriendRequest, deleteFriend, getFriendRequests, getFriends, handleFriendRequest } from '../controllers/friendControllers.js';
+import { addFriendRequest, deleteFriend, getFriendRequests, getFriends, handleFriendRequest, knockFriend } from '../controllers/friendControllers.js';
 import { jwtMiddleware } from '../middlewares/jwtMiddlewares.js';
 
 const router = express.Router();
@@ -14,4 +14,5 @@ router.post('/', addFriendRequest); // 친구 추가
 router.get('/requests', getFriendRequests); // 친구 요청 목록 조회
 router.patch('/requests/:friendRequestID', handleFriendRequest); // 친구 요청 수락/거절
 router.delete('/', deleteFriend);
+router.post('/knock', knockFriend);
 export default router;

--- a/src/routes/friendRoutes.js
+++ b/src/routes/friendRoutes.js
@@ -1,6 +1,6 @@
 import express from 'express';
+import { addFriendRequest, deleteFriend, getFriendRequests, getFriends, handleFriendRequest } from '../controllers/friendControllers.js';
 import { jwtMiddleware } from '../middlewares/jwtMiddlewares.js';
-import { addFriendRequest, getFriendRequests, getFriends, handleFriendRequest } from '../controllers/friendControllers.js';
 
 const router = express.Router();
 
@@ -13,5 +13,5 @@ router.get('/', getFriends); // 친구 목록 조회
 router.post('/', addFriendRequest); // 친구 추가
 router.get('/requests', getFriendRequests); // 친구 요청 목록 조회
 router.patch('/requests/:friendRequestID', handleFriendRequest); // 친구 요청 수락/거절
-
+router.delete('/', deleteFriend);
 export default router;


### PR DESCRIPTION
1. (package.json) node-cron, moment : 날짜 리셋과 설정을 위함 -> 실행 시 npm install 필수
2. 로그인 접속 상태
3. 친구 삭제 기능 DELETE /api/friends
- jwt 토큰 필요(user)
- 한번 삭제될 경우 친구 재신청 불가
- 삭제가 성공할 경우 다음과 같은 결과
![image](https://github.com/user-attachments/assets/a7bd14a7-2915-4015-8986-3a3938a5d734)


4. 노크 기능 POST /api/friends/knock
- jwt 토큰 필요(user)
- 노크는 일주일(월-일)에 한번만 가능(매주 월요일에 리셋)
- 노크를 두 번할 경우 알람은 전송되지 않으며 403 res
![image](https://github.com/user-attachments/assets/ef9d7a94-c544-4040-81c2-0d761bc91cad)

- 피드가 없을 경우 knock 메세지가 전송
![image](https://github.com/user-attachments/assets/c461b820-9eab-4ed9-91e0-bc226dc05aef)

- 피드가 있을 경우 다음과 같이 res
![image](https://github.com/user-attachments/assets/7b40c139-d205-4f5f-9cae-12e70d11b51c)
