### PR TITLE
fix - 친구 추가 요청 버그 수정 & 친구 삭제 시 friendRequest status DELETED 추가

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -47,6 +47,7 @@ enum FriendRequestStatus {
   PENDING // 요청 대기 상태
   ACCEPTED // 요청 수락 상태
   DECLINED // 요청 거절 상태
+  DELETED // 친구 삭제된 상태
 }
 
 model Friend {
@@ -77,6 +78,5 @@ model FriendFeed {
   userId       String   @db.ObjectId // 피드를 보는 사용자 ID
   feedId       String   @db.ObjectId // 친구의 피드 ID
   createdAt    DateTime @default(now()) // 연결이 생성된 시각
-
 }
 


### PR DESCRIPTION
1. 기존 Prisma에서 status로 DELETED 추가

enum FriendRequestStatus {
  PENDING // 요청 대기 상태
  ACCEPTED // 요청 수락 상태
  DECLINED // 요청 거절 상태
  DELETED // 친구 삭제된 상태
}

2. 친구 추가 요청시 상대가 보낸 요청이 존재해도 친구 요청이 중복으로 보내지는 버그 수정

3. 친구 삭제시 해당 친구 관계를 맺게 만들어준 friendRequest 테이블에서 해당 요청을 찾아서 status DELETED로 변경