### PR TITLE
fix - 친구 요청기능 삭제

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,6 +12,7 @@ datasource db {
   provider = "mongodb"
   url      = env("DATABASE_URL")
 }
+
 model User {
   id              String    @id @default(auto()) @map("_id") @db.ObjectId
   userID          String    @unique
@@ -22,32 +23,9 @@ model User {
   createdAt       DateTime  @default(now())
   updatedAt       DateTime  @default(now())
 
-  FriendRequests  FriendRequest[] @relation("Requester") // 사용자가 보낸 친구 요청들
-  ReceivedRequests FriendRequest[] @relation("Receiver") // 사용자가 받은 친구 요청들
-
   Friends          Friend[]        @relation("UserFriend") // 사용자가 추가한 친구 목록
   FriendUsers      Friend[]        @relation("FriendUser") // 사용자를 친구로 추가한 사용자 목록
   feeds            Feed[]          @relation("UserFeeds")
-}
-
-model FriendRequest {
-  id          String    @id @default(auto()) @map("_id") @db.ObjectId
-  requesterID String // 요청자(userID) 참조
-  receiverID  String // 요청 받은 사람(userID) 참조
-  status      FriendRequestStatus @default(PENDING) // 친구 요청 상태
-  createdAt   DateTime  @default(now()) 
-  updatedAt   DateTime  @default(now())
-
-  requester   User      @relation("Requester", fields: [requesterID], references: [userID]) // 요청 보낸 사용자
-  receiver    User      @relation("Receiver", fields: [receiverID], references: [userID]) // 요청 받은 사용자
-  @@unique([requesterID, receiverID]) // 동일한 사용자 간의 중복 요청 방지
-}
-
-enum FriendRequestStatus {
-  PENDING // 요청 대기 상태
-  ACCEPTED // 요청 수락 상태
-  DECLINED // 요청 거절 상태
-  DELETED // 친구 삭제된 상태
 }
 
 model Friend {

--- a/src/routes/friendRoutes.js
+++ b/src/routes/friendRoutes.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import { addFriendRequest, cheerOnFriendFeed, deleteFriend, getFriendRequests, getFriends, handleFriendRequest, knockFriend } from '../controllers/friendControllers.js';
+import { addFriend, cheerOnFriendFeed, deleteFriend, getFriends, knockFriend } from '../controllers/friendControllers.js';
 import { jwtMiddleware } from '../middlewares/jwtMiddlewares.js';
 
 const router = express.Router();
@@ -10,11 +10,9 @@ router.use(jwtMiddleware);
 // API 명세서 다 작성하지 않아서 경로명 임의로 정함
 
 router.get('/', getFriends); // 친구 목록 조회
-router.post('/', addFriendRequest); // 친구 추가
-router.get('/requests', getFriendRequests); // 친구 요청 목록 조회
-router.patch('/requests/:friendRequestID', handleFriendRequest); // 친구 요청 수락/거절
-router.delete('/', deleteFriend);
-router.post('/knock', knockFriend);
-router.post('/cheer/:feedId', cheerOnFriendFeed);
+router.post('/', addFriend); // 친구 추가
+router.delete('/', deleteFriend); // 친구 삭제제
+router.post('/knock', knockFriend); // 친구 노크하기
+router.post('/cheer/:feedId', cheerOnFriendFeed); // 친구 응원하기
 
 export default router;


### PR DESCRIPTION
1. Prisma의 FriendRequest 테이블 삭제
2. 기존 친구 추가 로직 수정
- 친구 추가 요청 => FriendRequest테이블 데이터 추가 => 상대방의 친구 요청 수락/거절 결정 => 수락시 Friend 테이블에 친구 관계 추가
3. 수정된 친구 추가 로직
- 친구 추가 => 곧바로 Friend 테이블에 친구 관계 추가
4. 수정된 친구 추가 로직으로 인해 일부 메소드 수정/삭제
- 친구 추가 요청 메소드/라우트 => 친구 추가 메소드/라우트 (POST /api/friends)
![스크린샷 2025-01-20 120210](https://github.com/user-attachments/assets/6ef39a14-00d5-4f4c-9431-72801b175d53)
- 친구 추가 요청 목록 조회 삭제 (GET /api/friends/requests)
- 친구 추가 요청 수락/거절 삭제 (PATCH /api/friends/requests/:requestID)
- 친구 삭제 메소드/라우트 유지 => 대신 FriendRequest에서 변경하는 로직만 삭제 (Friend관계 삭제만 하는 것으로 변경)