### PR TITLE
feat - 친구 고정/고정해제 추가, 사용자 회원 탈퇴 (연관된 데이터 Cascade 삭제) & fix - 친구 목록 조회…

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,6 +26,7 @@ model User {
   Friends          Friend[]        @relation("UserFriend") // 사용자가 추가한 친구 목록
   FriendUsers      Friend[]        @relation("FriendUser") // 사용자를 친구로 추가한 사용자 목록
   feeds            Feed[]          @relation("UserFeeds")
+  FriendFeeds      FriendFeed[]    @relation("FriendUserFeeds")
 }
 
 model Friend {
@@ -37,8 +38,8 @@ model Friend {
   fixedAt      DateTime? 
   knockedAt    DateTime? 
   createdAt    DateTime  @default(now())
-  user         User      @relation("UserFriend", fields: [userID], references: [userID]) // 친구 관계의 주체
-  friendUser   User      @relation("FriendUser", fields: [friendUserID], references: [userID]) // 친구 관계의 대상
+  user         User      @relation("UserFriend", fields: [userID], references: [userID], onDelete: Cascade) // 친구 관계의 주체
+  friendUser   User      @relation("FriendUser", fields: [friendUserID], references: [userID], onDelete: Cascade) // 친구 관계의 대상
 
   @@unique([userID, friendUserID], name: "userID_friendUserID") // 동일한 사용자 간 중복 친구 관계 방지
 }
@@ -48,15 +49,17 @@ model Feed {
   userID    String   // 사용자 ID 참조
   content   String
   createdAt DateTime @default(now())
-  user      User     @relation("UserFeeds", fields: [userID], references: [userID])
+  user      User     @relation("UserFeeds", fields: [userID], references: [userID], onDelete: Cascade)
 }
 
 model FriendFeed {
   friendFeedId String   @id @default(auto()) @map("_id") @db.ObjectId
-  userID       String   @db.ObjectId // 피드를 보는 사용자 ID
+  userID       String   // 피드를 보는 사용자 ID
   feedID       String   @db.ObjectId // 친구의 피드 ID
   cheer        Boolean  @default(false)
   createdAt    DateTime @default(now()) // 연결이 생성된 시각
+
+  user         User     @relation("FriendUserFeeds", fields: [userID], references: [userID], onDelete: Cascade)
 
   @@unique([userID, feedID], name: "userID_feedID")
 }

--- a/src/controllers/userControllers.js
+++ b/src/controllers/userControllers.js
@@ -132,3 +132,31 @@ export const updateProfileImage = async (req, res) => {
     res.status(500).json({ message: '프로필 이미지 업데이트 중 오류가 발생했습니다.' });
   }
 }
+
+// 사용자 회원탈퇴
+export const deleteUser = async (req, res) => {
+  const userID = req.user.userID; // 요청한 사용자의 userID 가져오기
+
+  try {
+    // 현재 요청한 사용자 조회
+    const currentUser = await prisma.user.findUnique({
+      where: { userID },
+    });
+
+    if (!currentUser) {
+      return res.status(404).json({ message: '사용자를 찾을 수 없습니다.' });
+    }
+
+    // 사용자 삭제 (연관된 데이터 Cascade로 삭제제)
+    await prisma.user.delete({
+      where: { userID },
+    });
+
+    res.status(200).json({
+      message: '회원 탈퇴가 성공적으로 완료되었습니다.',
+    });
+  } catch (err) {
+    console.error('회원탈퇴 오류:', err.message);
+    res.status(500).json({ message: '회원탈퇴 중 오류가 발생했습니다.' });
+  }
+}

--- a/src/routes/friendRoutes.js
+++ b/src/routes/friendRoutes.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import { addFriend, cheerOnFriendFeed, deleteFriend, getFriends, knockFriend } from '../controllers/friendControllers.js';
+import { addFriend, cheerOnFriendFeed, deleteFriend, getFriends, knockFriend, toggleFriendFix } from '../controllers/friendControllers.js';
 import { jwtMiddleware } from '../middlewares/jwtMiddlewares.js';
 
 const router = express.Router();
@@ -14,5 +14,6 @@ router.post('/', addFriend); // 친구 추가
 router.delete('/', deleteFriend); // 친구 삭제제
 router.post('/knock', knockFriend); // 친구 노크하기
 router.post('/cheer/:feedId', cheerOnFriendFeed); // 친구 응원하기
+router.patch('/fixed', toggleFriendFix); // 친구 고정/고정 해제하기기
 
 export default router;

--- a/src/routes/userRoutes.js
+++ b/src/routes/userRoutes.js
@@ -1,7 +1,7 @@
 import express from 'express';
 import multer from 'multer';
 import { jwtMiddleware } from '../middlewares/jwtMiddlewares.js';
-import { getCurrentUser, getUserFriendCode, updateNickname, updateProfileImage } from '../controllers/userControllers.js';
+import { deleteUser, getCurrentUser, getUserFriendCode, updateNickname, updateProfileImage } from '../controllers/userControllers.js';
 
 const router = express.Router();
 const upload = multer(); 
@@ -13,5 +13,6 @@ router.get('/', getCurrentUser); // 현재 사용자 정보 반환
 router.patch('/nickname', updateNickname); // 사용자 닉네임 업데이트
 router.patch('/profileImage', upload.single('profileImage'), updateProfileImage); // 사용자 프로필 이미지 업데이트
 router.get('/friendCode', getUserFriendCode); // 현재 사용자의 친구 코드 반환
+router.delete('/', deleteUser); // 현재 사용자 회원탈퇴퇴
 
 export default router;


### PR DESCRIPTION
… (고정된 순서 추가), Prisma DB 일부 수정 (Cascade관계 추가)

1. 친구 고정/고정해제 기능 추가 (PATCH '/api/friends/fixed')
- 평소 친구 데이터 상태 (isFixed : false, fixedAt: Null)
- 고정 X => 고정 O : isFixed: true, fixedAt: 고정한 시간
- 고정 O => 고정 X : isFixed : false, fixedAt: Null
![image](https://github.com/user-attachments/assets/b0567b66-585c-4ab3-adac-813bb68481ff)

2. 친구 목록 조회 (순서 추가)
- 1순위: 고정여부 확인
- 2순위: 고정된 친구 중 고정된 시간이 제일 빠른 순
- 3순위: 고정 X친구 중 먼저 맺어진 친구 순

3. 사용자 회원탈퇴 추가 (DELETE '/api/users')
 (Prisma에서 userID를 참조하는 모든 테이블의 데이터 On Delete Cascade 설정)
 
![image](https://github.com/user-attachments/assets/58aa04d4-d76e-434c-b0be-ca0ddcbf8101)

4. 기존 FriendFeed 테이블에 저장되던 userID 저장항목 수정
![image](https://github.com/user-attachments/assets/1905b757-8b27-40ae-8fa3-b7f068be267f)

