### PR TITLE
Develop

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -76,7 +76,7 @@ model Moment {
   date        DateTime
   complete    Boolean
   userID      String
-  user        User     @relation("UserMoments", fields: [userID], references: [userID])
+  user        User     @relation("UserMoments", fields: [userID], references: [userID], onDelete: Cascade)
   bucketID    String   @db.ObjectId
   bucket      Bucket   @relation("BucketMoments", fields: [bucketID], references: [bucketID], onDelete: Cascade)
 }
@@ -88,7 +88,7 @@ model Notification {
   createdAt      DateTime
   isRead         Boolean          @default(false)
   userID         String
-  user           User             @relation("UserNotifications", fields: [userID], references: [userID])
+  user           User             @relation("UserNotifications", fields: [userID], references: [userID], onDelete: Cascade)
 }
 
 enum NotificationType {
@@ -103,7 +103,7 @@ model Bucket {
   updatedAt DateTime?  @updatedAt
   moments   Moment[]   @relation("BucketMoments")
   userID    String
-  user      User       @relation("UserBuckets", fields: [userID], references: [userID])
+  user      User       @relation("UserBuckets", fields: [userID], references: [userID], onDelete: Cascade)
 }
 
 enum BucketType {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -78,7 +78,7 @@ model Moment {
   updatedAt     DateTime @updatedAt
 
   // 어떤 버킷에 속하는지
-  bucketID      String
+  bucketID      String   @db.ObjectId
   bucket        Bucket   @relation("BucketMoments", fields: [bucketID], references: [bucketID], onDelete: Cascade)
 
   // 누가 생성했는지 (필요하다면)

--- a/src/app.js
+++ b/src/app.js
@@ -15,8 +15,16 @@ dotenv.config({override: true});
 
 const app = express();
 
+const corsOptions = {
+  origin: [
+    'http://localhost:5173', // 프론트엔드 로컬 환경
+    'https://codeit.momentum.vercel.app', // 프론트엔드 배포 환경
+  ],
+  credentials: true, // 쿠키 및 인증 헤더 허용
+}
+
 // 미들웨어, 라우트 등등 (Express 애플리케이션 설정)
-app.use(cors());
+app.use(cors(corsOptions));
 app.use(bodyParser.json());
 app.use(cookieParser());
 app.use('/auth', authRoutes);

--- a/src/app.js
+++ b/src/app.js
@@ -34,7 +34,8 @@ app.use('/api/home', homeRoutes);
 app.use('/api/moment', momentRoutes);
 
 console.log('Current Environment:', process.env.NODE_ENV);
-console.log('Redirect URI:', process.env.REDIRECT_URI);
+console.log('Redirect URI LOCAL:', process.env.REDIRECT_URI_LOCAL);
+console.log('Redirect URI DEPLOY:', process.env.REDIRECT_URI_DEPLOY);
 console.log('REST_API_KEY:', process.env.REST_API_KEY);
 
 export default app;

--- a/src/controllers/authControllers.js
+++ b/src/controllers/authControllers.js
@@ -7,7 +7,14 @@ const prisma = new PrismaClient();
 
 // 카카오 로그인 페이지로 리디렉션 (프론트에서 하는 작업) (테스트용)
 export const redirectToKakaoLogin = (req, res) => {
-    const kakaoAuthUrl = `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${process.env.REST_API_KEY}&redirect_uri=${process.env.REDIRECT_URI}`;
+    const origin = req.headers.origin || 'http://localhost:3000'; // 요청 헤더의 Origin 감지
+    // 동적으로 REDIRECT_URI 설정
+    const redirectUri =
+        origin.includes('localhost') // 로컬
+            ? process.env.REDIRECT_URI_LOCAL // 로컬 환경의 리다이렉션 URI (프론트엔드)
+            : process.env.REDIRECT_URI_DEPLOY; // 배포 환경의 리다이렉션 URI
+
+    const kakaoAuthUrl = `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${process.env.REST_API_KEY}&redirect_uri=${redirectUri}`;
     res.redirect(kakaoAuthUrl); // 사용자 브라우저를 카카오 로그인 페이지로 리디렉션
 };
 
@@ -26,13 +33,18 @@ export const handleKakaoCallback = (req, res) => {
 
 export const kakaoLogin = async (req, res) => {
     const { code } = req.body; // 클라이언트에서 받은 인가 코드
+    const origin = req.headers.origin || 'http://localhost:3000'; // 요청 헤더의 Origin 감지
 
+    const redirectUri =
+        origin.includes('localhost') // 로컬
+            ? process.env.REDIRECT_URI_LOCAL // 로컬 환경의 리다이렉션 URI (프론트엔드)
+            : process.env.REDIRECT_URI_DEPLOY; // 배포 환경의 리다이렉션 URI
     try {
         const response = await axios.post('https://kauth.kakao.com/oauth/token', null, {
             params: {
             grant_type: 'authorization_code',
             client_id: process.env.REST_API_KEY,
-            redirect_uri: process.env.REDIRECT_URI,
+            redirect_uri: redirectUri, // 감지된 리다이렉션 URI 사용
             code: code,
             },
         });

--- a/src/controllers/authControllers.js
+++ b/src/controllers/authControllers.js
@@ -114,8 +114,12 @@ export const handleKakaoUser = async (req, res) => {
             // 기본 닉네임 생성 (사용자의 이메일 @ 앞 부분을 따옴)
             const nickname = email.split('@')[0]; // 이메일의 @ 앞부분 반환
 
-            // 기본 프로필 이미지 URL 설정
-            const defaultProfileImageUrl = "https://momentum-s3-bucket.s3.ap-northeast-2.amazonaws.com/profile/basic/free-icon-profile-4519729.png"; // 추후에 실제 기본 프로필 이미지로 변경 필요
+            // 기본 프로필 이미지 URL 설정 (랜덤 선택)
+            const profileImages = [
+                "https://momentum-s3-bucket.s3.ap-northeast-2.amazonaws.com/profile/basic/Momentum_Icon_NullProfile.png",
+                "https://momentum-s3-bucket.s3.ap-northeast-2.amazonaws.com/profile/basic/Momentum_Icon_NullProfile(Black).png"
+            ];
+            const defaultProfileImageUrl = profileImages[Math.floor(Math.random() * profileImages.length)];
 
             // 사용자가 없으면 새로 생성
             user = await prisma.user.create({

--- a/src/controllers/userControllers.js
+++ b/src/controllers/userControllers.js
@@ -105,7 +105,7 @@ export const updateProfileImage = async (req, res) => {
     }
 
     const bucketName = process.env.AWS_S3_BUCKET_NAME;
-    const key = `profile/custom/${req.user.userID}-${Date.now()}`;
+    const key = `profile/custom/${req.user.userID}/${req.user.userID}-${Date.now()}`;
 
     const command = new PutObjectCommand({
       Bucket: bucketName,
@@ -151,7 +151,7 @@ export const updateProfile = async (req, res) => {
     // 프로필 이미지 처리
     if (req.file) {
       const bucketName = process.env.AWS_S3_BUCKET_NAME;
-      const key = `profile/custom/${req.user.userID}-${Date.now()}`;
+      const key = `profile/custom/${req.user.userID}/${req.user.userID}-${Date.now()}`;
 
       const command = new PutObjectCommand({
         Bucket: bucketName,

--- a/src/controllers/userControllers.js
+++ b/src/controllers/userControllers.js
@@ -147,7 +147,7 @@ export const deleteUser = async (req, res) => {
       return res.status(404).json({ message: '사용자를 찾을 수 없습니다.' });
     }
 
-    // 사용자 삭제 (연관된 데이터 Cascade로 삭제제)
+    // 사용자 삭제 (연관된 데이터 Cascade로 삭제)
     await prisma.user.delete({
       where: { userID },
     });

--- a/src/controllers/userControllers.js
+++ b/src/controllers/userControllers.js
@@ -133,6 +133,67 @@ export const updateProfileImage = async (req, res) => {
   }
 }
 
+// 사용자 닉네임 & 프로필 이미지 업데이트
+export const updateProfile = async (req, res) => {
+  try {
+    const { newNickname } = req.body; // 새 닉네임
+    let profileImageUrl = null; // 프로필 이미지 URL 초기화
+
+    if (!newNickname) {
+      return res.status(400).json({ message: '새 닉네임이 필요합니다.' });
+    }
+
+    // 닉네임 검증
+    if (newNickname && newNickname.length > 20) {
+      return res.status(400).json({ message: '닉네임은 최대 20자까지 가능합니다.' });
+    }
+
+    // 프로필 이미지 처리
+    if (req.file) {
+      const bucketName = process.env.AWS_S3_BUCKET_NAME;
+      const key = `profile/custom/${req.user.userID}-${Date.now()}`;
+
+      const command = new PutObjectCommand({
+        Bucket: bucketName,
+        Key: key,
+        Body: req.file.buffer, // Multer는 파일 데이터를 buffer로 제공
+        ContentType: req.file.mimetype, // 파일의 MIME 타입
+      });
+
+      await s3Client.send(command);
+      profileImageUrl = `https://${bucketName}.s3.${process.env.AWS_REGION}.amazonaws.com/${key}`;
+    }
+
+    // 사용자 정보 업데이트
+    const updatedData = {};
+    if (newNickname) updatedData.nickname = newNickname; // 닉네임 업데이트
+    if (profileImageUrl) updatedData.profileImageUrl = profileImageUrl; // 프로필 이미지 업데이트
+
+    if (Object.keys(updatedData).length === 0) {
+      return res.status(400).json({ message: '변경할 닉네임 또는 프로필 이미지를 제공해주세요.' });
+    }
+
+    const updatedUser = await prisma.user.update({
+      where: { userID: req.user.userID },
+      data: updatedData,
+      select: {
+        userID: true,
+        nickname: true,
+        email: true,
+        profileImageUrl: true,
+      },
+    });
+
+    res.status(200).json({
+      message: '사용자 정보가 성공적으로 업데이트되었습니다.',
+      user: updatedUser,
+    });
+  } catch (err) {
+    console.error('사용자 정보 업데이트 오류:', err.message);
+    res.status(500).json({ message: '사용자 정보 업데이트 중 오류가 발생했습니다.' });
+  }
+}
+
 // 사용자 회원탈퇴
 export const deleteUser = async (req, res) => {
   const userID = req.user.userID; // 요청한 사용자의 userID 가져오기

--- a/src/routes/authRoutes.js
+++ b/src/routes/authRoutes.js
@@ -1,21 +1,12 @@
 import express from 'express';
 import { redirectToKakaoLogin, handleKakaoCallback, handleKakaoUser, kakaoLogin } from '../controllers/authControllers.js';
-import { jwtMiddleware } from '../middlewares/jwtMiddlewares.js';
+
 const router = express.Router();
 
 
 router.get('/kakao', redirectToKakaoLogin); // 카카오 로그인 페이지로 리디렉션 (프론트에서 하는 작업) (테스트용)
 router.get('/kakao/callback', handleKakaoCallback); // 카카오에서 인가 코드를 수신하는 콜백 URL (프론트에서 하는 작업) (테스트용)
-
 router.post('/kakao-login', kakaoLogin); // 카카오 액세스 토큰 요청
 router.post('/kakao-login/user', handleKakaoUser); // 카카오 사용자 정보 처리
-
-// jwtMiddleware 테스트용
-router.get('/profile', jwtMiddleware, (req, res) => {
-  res.json({
-    message: '프로필 조회 성공',
-    user: req.user, // jwtMiddleware에서 설정한 사용자 정보
-  });
-});
 
 export default router;

--- a/src/routes/momentRoutes.js
+++ b/src/routes/momentRoutes.js
@@ -1,9 +1,11 @@
 import express from 'express';
+import multer from 'multer';
 import { createBucket, deleteBucket, updateBucket } from '../controllers/bucketControllers.js';
 import { createMoments, getMomentsByBucket, updateMoment } from '../controllers/momentControllers.js';
 import { jwtMiddleware } from '../middlewares/jwtMiddlewares.js';
 
 const router = express.Router();
+const upload = multer();
 
 // 인증 미들웨어 적용 (jwt 토큰)
 router.use(jwtMiddleware);
@@ -15,7 +17,7 @@ router.delete('/bucket/:bucketID', deleteBucket); // 버킷리스트 삭제
 //모멘트 등록 조회(bucketID)
 router.post('/buckets/:bucketID/moments', createMoments);
 router.get('/buckets/:bucketID/moments', getMomentsByBucket);
-router.patch('/moments/:momentID', updateMoment); //모멘트 달성
+router.patch('/moments/:momentID', upload.single('photoUrl'), updateMoment); //모멘트 달성
 
 
 export default router;

--- a/src/routes/userRoutes.js
+++ b/src/routes/userRoutes.js
@@ -1,7 +1,7 @@
 import express from 'express';
 import multer from 'multer';
 import { jwtMiddleware } from '../middlewares/jwtMiddlewares.js';
-import { deleteUser, getCurrentUser, getUserFriendCode, updateNickname, updateProfileImage } from '../controllers/userControllers.js';
+import { deleteUser, getCurrentUser, getUserFriendCode, updateNickname, updateProfile, updateProfileImage } from '../controllers/userControllers.js';
 
 const router = express.Router();
 const upload = multer(); 
@@ -12,6 +12,7 @@ router.use(jwtMiddleware);
 router.get('/', getCurrentUser); // 현재 사용자 정보 반환
 router.patch('/nickname', updateNickname); // 사용자 닉네임 업데이트
 router.patch('/profileImage', upload.single('profileImage'), updateProfileImage); // 사용자 프로필 이미지 업데이트
+router.patch('/profile', upload.single('profileImage'), updateProfile); // 닉네임 및 프로필 이미지 업데이트
 router.get('/friendCode', getUserFriendCode); // 현재 사용자의 친구 코드 반환
 router.delete('/', deleteUser); // 현재 사용자 회원탈퇴퇴
 


### PR DESCRIPTION
1. app.js의 cors설정에 corsOptions으로 다음과 같이 추가
{
  origin: [
    'http://localhost:5173', // 프론트엔드 로컬 환경
    'https://codeit.momentum.vercel.app', // 프론트엔드 배포 환경
  ],
  credentials: true, // 쿠키 및 인증 헤더 허용
}

2. authController의 카카오 리디렉션 변경
- 기존 REDIRECT_URI 동적으로 origin이 localhost인지 아니면 배포한 서버인지에 따라 REDIRECT_URI_LOCAL, REDIRECT_URI_DEPLOY로 설정
- 프론트 측에서 실험결과를 알려줘야함 (프론트측 배포환경 & 로컬개발 환경에서도 모두 동작 가능하게하기 위해)

**중요**
- .env.production과 .env.development에 각각 직접 업데이트 필요
- 해당 사항은 Notion의 기초작업 (설정)에 업데이트 해둠
- https://www.notion.so/080072afb77346d78f7a9fd8f0b0fade

3. 모멘트 달성 인증을 위한 사진 첨부 AWS S3에 저장되도록 변경
![image](https://github.com/user-attachments/assets/865a2056-0781-4d17-8e71-19b4fdafbe45)


아직 모멘트 테이블에 isChallenging? 항목이 없어서 테스트하는 중에 오류 나서 코드를 임시로 수정해서 테스트 진행했습니다! 물론 깃에는 원래하시던걸로 올려뒀습니다.
