### PR TITLE
moment count 로직 수정 및 prisma db default 수정

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -73,15 +73,15 @@ model Moment {
   momentID      String   @id @default(auto()) @map("_id") @db.ObjectId
   content       String
   isCompleted   Boolean  @default(false)
-  photoUrl      String?  // 인증사진
+  photoUrl      String?  @default("")// 인증사진
   createdAt     DateTime @default(now())
   updatedAt     DateTime @updatedAt
 
   // 어떤 버킷에 속하는지
   bucketID      String   @db.ObjectId
   bucket        Bucket   @relation("BucketMoments", fields: [bucketID], references: [bucketID], onDelete: Cascade)
-  startDate     DateTime?
-  endDate       DateTime?
+  startDate     DateTime?   @default(now())
+  endDate       DateTime?   @default("2025-12-31T00:00:00.000Z")
   
   userID        String
   user          User     @relation("UserMoments", fields: [userID], references: [userID], onDelete: Cascade)
@@ -112,8 +112,8 @@ model Bucket {
   isChallenging Boolean     @default(false)
   momentsCount          Int @default(0)
   completedMomentsCount Int @default(0)
-  startDate     DateTime?   
-  endDate       DateTime?   
+  startDate     DateTime?   @default(now())
+  endDate       DateTime?   @default("2025-12-31T00:00:00.000Z") 
   createdAt     DateTime    @default(now())
   updatedAt     DateTime?   @updatedAt
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -80,7 +80,8 @@ model Moment {
   // 어떤 버킷에 속하는지
   bucketID      String   @db.ObjectId
   bucket        Bucket   @relation("BucketMoments", fields: [bucketID], references: [bucketID], onDelete: Cascade)
-
+  startDate     DateTime?
+  endDate       DateTime?
   
   userID        String
   user          User     @relation("UserMoments", fields: [userID], references: [userID], onDelete: Cascade)
@@ -117,7 +118,7 @@ model Bucket {
   updatedAt     DateTime?  @updatedAt
 
   userID        String
-  user          User       @relation("UserBuckets", fields: [userID], references: [userID])
+  user          User       @relation("UserBuckets", fields: [userID], references: [userID], onDelete: Cascade)
 
   moments       Moment[]   @relation("BucketMoments")
 }

--- a/src/controllers/bucketControllers.js
+++ b/src/controllers/bucketControllers.js
@@ -258,10 +258,14 @@ export const getBucketDetail = async (req, res) => {
             error: { code: 403, message: '버킷 조회 권한이 없습니다.' },
             });
         }
-    
+        const momentsCount = bucket.moments.length;
+        const completedMomentsCount = bucket.moments.filter((moment) => moment.isCompleted === true).length;
+        
         return res.status(200).json({
             success: true,
             bucket,
+            momentsCount,
+            completedMomentsCount,
         });
         } catch (error) {
         console.error('버킷 상세 조회 실패:', error);

--- a/src/controllers/momentControllers.js
+++ b/src/controllers/momentControllers.js
@@ -76,6 +76,8 @@ export const createMoments = async (req, res) => {
                     content: m.content || '',
                     photoUrl: null,
                     isCompleted: false,
+                    startDate: new Date(m.startDate),
+                    endDate: new Date(m.endDate),
                     bucketID: bucketID,
                     userID: userID,
                     },


### PR DESCRIPTION
- 로직만 수정했기 때문에 (사진 인증시 달성으로 처리) 기본 실행 방법과 사용 방법은 동일함
- + moment 생성 시 start와 end date 받아오기
-  prisma db 디폴트값 수정, db 저장 시 모든 필드가 뜨도록
- 필요없는 로직 수정

momentsCount : 전체 모멘트 수
completedMomentsCount: 달성한 모멘트 수
홈화면 및 모멘트 화면 % 사용 시 참고
