### PR TITLE
momentsCount DB 삭제, 실시간계산 로직으로 사용

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -110,8 +110,6 @@ model Bucket {
   isCompleted   Boolean?    @default(false) // 달성형이 완료됐는지
 
   isChallenging Boolean     @default(false)
-  momentsCount          Int @default(0)
-  completedMomentsCount Int @default(0)
   startDate     DateTime?   @default(now())
   endDate       DateTime?   @default("2025-12-31T00:00:00.000Z") 
   createdAt     DateTime    @default(now())


### PR DESCRIPTION
momentsCount와 completeMomentsCount 갯수가 DB 직접 저장하지 않고 실시간 계산을 하는 방식으로 바꿈.
getBucketDetail - 조회 API를 사용하면 momentsCount와 completeMomentsCount 를 확인할 수 있음