### PR TITLE
fix - 모멘트 & 버킷 기능 수정

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -110,8 +110,8 @@ model Bucket {
   isCompleted   Boolean?    @default(false) // 달성형이 완료됐는지
 
   isChallenging Boolean     @default(false)
-  startDate     DateTime?   @default(now())
-  endDate       DateTime?   @default("2025-12-31T00:00:00.000Z") 
+  startDate     DateTime? 
+  endDate       DateTime?  
   createdAt     DateTime    @default(now())
   updatedAt     DateTime?   @updatedAt
 

--- a/src/controllers/bucketControllers.js
+++ b/src/controllers/bucketControllers.js
@@ -51,16 +51,16 @@ export const uploadAchievementPhoto = async (req, res) => {
 
         const bucket = await prisma.bucket.findUnique({ where: { bucketID } });
         if (!bucket) {
-        return res.status(404).json({
-            success: false,
-            error: { code: 404, message: '버킷을 찾을 수 없습니다.' },
-        });
+            return res.status(404).json({
+                success: false,
+                error: { code: 404, message: '버킷을 찾을 수 없습니다.' },
+            });
         }
         if (bucket.userID !== userID) {
-        return res.status(403).json({
-            success: false,
-            error: { code: 403, message: '버킷 수정 권한이 없습니다.' },
-        });
+            return res.status(403).json({
+                success: false,
+                error: { code: 403, message: '버킷 수정 권한이 없습니다.' },
+            });
         }
 
         // 달성형인지
@@ -96,30 +96,17 @@ export const uploadAchievementPhoto = async (req, res) => {
             isCompleted: true,  // 달성 완료
         },
         });
-        
-        // 3) "모두 완료" 체크 (completedMomentsCount === momentsCount)
-        const bucketState = await tx.bucket.findUnique({
-            where: { bucketID },
-            select: { completedMomentsCount: true, momentsCount: true },
-        });
-
-        if (bucketState.completedMomentsCount === bucketState.momentsCount) {
-            await tx.bucket.update({
-                where: { bucketID },
-                data: { isCompleted: true, updatedAt: new Date() },
-            });
-        }
 
         return res.status(200).json({
-        success: true,
-        message: '달성형 버킷이 인증되어 완료 처리되었습니다.',
-        bucket: updatedBucket,
+            success: true,
+            message: '달성형 버킷이 인증되어 완료 처리되었습니다.',
+            bucket: updatedBucket,
         });
     } catch (error) {
         console.error('달성형 버킷 인증사진 업로드 실패:', error);
         return res.status(500).json({
-        success: false,
-        error: { code: 500, message: '서버 내부 오류가 발생했습니다.' },
+            success: false,
+            error: { code: 500, message: '서버 내부 오류가 발생했습니다.' },
         });
     }
 };
@@ -355,6 +342,7 @@ export const updateBucket = async (req, res) => {
     }
 };
 
+// 완료된 버킷리스트 개수 출력
 export const getCompletedBuckets = async (req, res) => {
     try {
         const userID = req.user.userID;

--- a/src/controllers/friendControllers.js
+++ b/src/controllers/friendControllers.js
@@ -93,7 +93,7 @@ export const addFriend = async (req, res) => {
       return res.status(409).json({ message: '이미 친구 관계입니다.' });
     }
 
-    // 즉시 친구 관계 생성 (친구 요청 패스스)
+    // 즉시 친구 관계 생성 (친구 요청 패스)
     await prisma.friend.createMany({
       data: [
         {

--- a/src/controllers/momentControllers.js
+++ b/src/controllers/momentControllers.js
@@ -120,6 +120,17 @@ export const getMomentsByBucket = async (req, res) => {
             });
         }
 
+        // 버킷 타입 체크 (ACHIEVEMENT이면 조회 불가)
+        if (bucket.type === 'ACHIEVEMENT') {
+            return res.status(400).json({
+                success: false,
+                error: {
+                    code: 400,
+                    message: '이 버킷은 반복형(REPEAT) 버킷만 조회할 수 있습니다.',
+                },
+            });
+        }
+
         //모멘트 목록 조회
         const moments = await prisma.moment.findMany({
             where: { bucketID },

--- a/src/controllers/momentControllers.js
+++ b/src/controllers/momentControllers.js
@@ -246,3 +246,43 @@ export const updateMoment = async (req, res) => {
         });
     }
 };
+
+export const getDetailMoment = async (req, res) => {
+    try {
+        const userID = req.user.userID; // 인증된 사용자 ID
+        const { momentID } = req.params; // 요청된 momentID
+
+        // 모멘트 조회
+        const moment = await prisma.moment.findUnique({
+            where: { momentID },
+            include: { bucket: true }, // 관련된 버킷 정보를 포함
+        });
+
+        // 모멘트가 존재하지 않을 경우 처리
+        if (!moment) {
+            return res.status(404).json({
+                success: false,
+                error: { code: 404, message: '모멘트를 찾을 수 없습니다.' },
+            });
+        }
+
+        // 소유자 확인
+        if (moment.userID !== userID) {
+            return res.status(403).json({
+                success: false,
+                error: { code: 403, message: '모멘트 상세 정보를 확인할 권한이 없습니다.' },
+            });
+        }
+
+        return res.status(200).json({
+            success: true,
+            moment,
+        });
+    } catch (err) {
+        console.error('모멘트 상세 조회 실패:', error);
+        return res.status(500).json({
+            success: false,
+            error: { code: 500, message: '서버 내부 오류가 발생했습니다.' },
+        });
+    }
+}

--- a/src/routes/momentRoutes.js
+++ b/src/routes/momentRoutes.js
@@ -1,7 +1,7 @@
 import express from 'express';
 import multer from 'multer';
 import { activateBucketChallenge, createBucket, deactivateBucketChallenge, getBucketDetail, getCompletedBuckets, updateBucket, uploadAchievementPhoto } from '../controllers/bucketControllers.js';
-import { createMoments, getMomentsByBucket, updateMoment } from '../controllers/momentControllers.js';
+import { createMoments, getDetailMoment, getMomentsByBucket, updateMoment } from '../controllers/momentControllers.js';
 import { jwtMiddleware } from '../middlewares/jwtMiddlewares.js';
 
 const router = express.Router();
@@ -18,12 +18,13 @@ router.patch('/:bucketID/un-challenge', deactivateBucketChallenge); // 혹시 �
 
 router.get('/completed-count', getCompletedBuckets); // 완료된 버킷리스트 갯수(홈 화면 이용)
 router.get('/:bucketID', getBucketDetail); // 버킷리스트 상세 조회
-router.patch('/:bucketID', updateBucket); //버킷 이름 수정
+router.patch('/:bucketID', updateBucket); // 버킷 이름 수정
 
 
 //모멘트 등록 조회(bucketID)
 router.post('/moments/:bucketID/moments', createMoments);
-router.get('/moments/:bucketID/moments', getMomentsByBucket);
+router.get('/moments/:bucketID/moments', getMomentsByBucket); // (반복형) 버킷리스트의 모멘트들 조회
+router.get('/moments/:momentID', getDetailMoment); // 선택한 모멘트의 상세 조회
 router.patch('/moments/:momentID', upload.single('photoUrl'), updateMoment); //모멘트 달성
 
 


### PR DESCRIPTION
현재 사용자, 친구, 모멘트, 버킷 기능 점검완료 (계속 반복 진행 예정)

1. Bucket 테이블의 변경된 사항에 맞춰서, 버킷 & 모멘트 기능에서 momentCount, completedMomentsCount 저장 및 확인 기능 삭제 및 수정

2. startDate, endDate 모멘트 생성시 자동으로 MongoDB에 자동으로 잘 반영이 되는게 확인이 되어, startDate, endDate의 @default()값 삭제 (shema.prisma 확인)

3. 버킷 상세 조회시 (getMomentsByBucket), 버킷 타입이 ACHIEVEMENT인 경우 에러코드가 나오도록 추가 (모멘트는 반복형에서만 조회 가능하므로)

4. 상세 모멘트 조회 기능 추가 (getDetailMoment) (추후에 필요할 수도 있을것 같아 추가)
GET ('/moments/:momentID')

POSTMAN API 명세소로 기능 테스트한 것 확인 가능
https://documenter.getpostman.com/view/34749163/2sAYQfEVUY
 