### PR TITLE
bucket isCompleted 버그 수정, check-friendCode 로직 구현

### DIFF
--- a/src/controllers/bucketControllers.js
+++ b/src/controllers/bucketControllers.js
@@ -263,7 +263,7 @@ export const getBucketDetail = async (req, res) => {
             const completedMomentsCount = bucket.moments.filter((moment) => moment.isCompleted === true).length;
 
             
-            if (completedMomentsCount === momentsCount && !bucket.isCompleted) {
+            if (completedMomentsCount === momentsCount && !bucket.isCompleted && momentsCount !== 0) {
                 await tx.bucket.update({
                     where: { bucketID },
                     data: { isCompleted: true, updatedAt: new Date() },

--- a/src/controllers/friendControllers.js
+++ b/src/controllers/friendControllers.js
@@ -51,6 +51,40 @@ export const getFriends = async (req, res) => {
   }
 };
 
+
+// 친구추가 전 친구 닉네임 GET
+export const checkFriendCode = async (req, res) => {
+  const { friendCode } = req.body; // 클라이언트로부터 받은 친구 코드
+
+  // 친구코드가 없는 경우 에러 반환
+  if (!friendCode) {
+    return res.status(400).json({ message: '친구코드가 필요합니다.' });
+  }
+
+  try {
+    // 친구코드로 사용자 조회
+    const user = await prisma.user.findUnique({
+      where: { friendCode },
+      select: { nickname: true }, // 닉네임만 조회
+    });
+
+    // 친구코드가 유효하지 않은 경우
+    if (!user) {
+      return res.status(404).json({ message: '유효하지 않은 친구코드입니다.' });
+    }
+
+    // 닉네임 반환
+    res.status(200).json({
+      message: '친구코드 확인 성공',
+      nickname: user.nickname,
+    });
+  } catch (err) {
+    console.error('친구 코드 확인 오류:', err.message);
+    res.status(500).json({ message: '친구코드를 확인하는 중 오류가 발생했습니다.' });
+  }
+};
+
+
 // 사용자 친구 추가
 export const addFriend = async (req, res) => {
   const { friendCode } = req.body;

--- a/src/controllers/userControllers.js
+++ b/src/controllers/userControllers.js
@@ -1,6 +1,6 @@
+import { PutObjectCommand } from '@aws-sdk/client-s3';
 import { PrismaClient } from '@prisma/client';
 import { s3Client } from '../config/s3config.js';
-import { PutObjectCommand } from '@aws-sdk/client-s3';
 
 const prisma = new PrismaClient();
 
@@ -38,7 +38,7 @@ export const getUserFriendCode = async (req, res) => {
     if (!currentUser) { // 현재 사용자가 없는 경우
       return res.status(404).json({ message: '현재 사용자를 찾을 수 없습니다.' });
     }
-
+    
     // 사용자 정보 반환
     res.status(200).json({
       message: '사용자의 친구 코드 접근 성공',

--- a/src/routes/friendRoutes.js
+++ b/src/routes/friendRoutes.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import { addFriend, cheerOnFriendFeed, deleteFriend, getFriends, knockFriend, toggleFriendFix } from '../controllers/friendControllers.js';
+import { addFriend, checkFriendCode, cheerOnFriendFeed, deleteFriend, getFriends, knockFriend, toggleFriendFix } from '../controllers/friendControllers.js';
 import { jwtMiddleware } from '../middlewares/jwtMiddlewares.js';
 
 const router = express.Router();
@@ -11,6 +11,7 @@ router.use(jwtMiddleware);
 
 router.get('/', getFriends); // 친구 목록 조회
 router.post('/', addFriend); // 친구 추가
+router.post('/check-friendCode', checkFriendCode); // 친구 코드 확인
 router.delete('/', deleteFriend); // 친구 삭제제
 router.post('/knock', knockFriend); // 친구 노크하기
 router.post('/cheer/:feedId', cheerOnFriendFeed); // 친구 응원하기


### PR DESCRIPTION
1. bucket 에서 isChallenge를 활성화 한 후 모멘트를 생성하기 전(전체: 0, 달성: 0)으로 부터 발생하는 isCompleted=true 버그 해결
 -> 0을 예외처리하여 모멘트를 생성하기 전에 isCompleted상태는 false가 되도록

2. 프론트 측에서 요구한 친구확인용 로직 구현
- 친구의 친구코드 입력은 친구 신청과 동일하게 되어있지만, 수락하지 않고 닉네임만 먼저 반환해주는 기능
- POST /api/friends/check-friendCode
- request: friendCode / response: nickname
- 테스트 및 예외처리 완료

![image](https://github.com/user-attachments/assets/bf04857b-f29e-4179-9663-a8394e18193f)
