### PR TITLE
모멘트 상세 조회 라우터 수정

### DIFF
--- a/src/routes/momentRoutes.js
+++ b/src/routes/momentRoutes.js
@@ -24,7 +24,7 @@ router.patch('/:bucketID', updateBucket); // 버킷 이름 수정
 //모멘트 등록 조회(bucketID)
 router.post('/moments/:bucketID', createMoments);
 router.get('/moments/:bucketID', getMomentsByBucket); // (반복형) 버킷리스트의 모멘트들 조회
-router.get('/moments/:momentID', getDetailMoment); // 선택한 모멘트의 상세 조회
+router.get('/moment/:momentID', getDetailMoment); // 선택한 모멘트의 상세 조회
 router.patch('/moments/:momentID', upload.single('photoUrl'), updateMoment); //모멘트 달성
 
 


### PR DESCRIPTION
버킷리스트 상세 조회와 선택한 모멘트 상세 조회의 라우터가 겹치는 이슈 발생
모멘트 상세 조회의 라우터를 수정 moments -> moment       GET /api/bucket/moment/:momentID