### PR TITLE
버킷리스트 전체 조회 분류(달성형, 반복형)

### DIFF
--- a/src/controllers/bucketControllers.js
+++ b/src/controllers/bucketControllers.js
@@ -406,3 +406,38 @@ export const getRepeatBuckets = async (req, res) => {
         });
     }
 };
+
+export const getAchievementBuckets = async (req, res) => {
+    try {
+        const userID = req.user.userID;
+    
+        // 1) ACHIEVEMENT 타입 && 해당 userID의 버킷 조회
+        const buckets = await prisma.bucket.findMany({
+            where: {
+                userID,
+                type: 'ACHIEVEMENT',
+            },
+            select: {
+                bucketID: true,  
+                content: true,
+                isCompleted: true,
+            // isChallenging 필드는 달성형에 의미 없으므로 제외
+            },
+            orderBy: { createdAt: 'desc' },
+        });
+    
+        return res.status(200).json({
+            success: true,
+            user: userID,
+            count: buckets.length,
+            type: 'ACHIEVEMENT 달성형',
+            buckets,
+        });
+        } catch (error) {
+        console.error('달성형 버킷 조회 실패:', error);
+        return res.status(500).json({
+            success: false,
+            error: { code: 500, message: '서버 내부 오류가 발생했습니다.' },
+        });
+    }
+};

--- a/src/controllers/bucketControllers.js
+++ b/src/controllers/bucketControllers.js
@@ -369,62 +369,37 @@ export const getCompletedBuckets = async (req, res) => {
     }
 };
 
-export const getAllUserBuckets = async (req, res) => {
+
+export const getRepeatBuckets = async (req, res) => {
     try {
-      // JWT 인증 후, authMiddleware에서 세팅된 유저 정보
         const userID = req.user.userID;
-    
-        // 1) userID로 버킷들 조회 (findMany)
-        //    Bucket -> User(userID, nickname) 관계를 select
+      // 1) Bucket 중 type=REPEAT 만 조회
         const buckets = await prisma.bucket.findMany({
-            where: { userID },
+            where: {
+                type: 'REPEAT',
+                userID,
+            },
             select: {
-            bucketID: true,
-            content: true,
-            isCompleted: true,
-            user: {
-                select: {
-                userID: true,
-                nickname: true,
-                },
+                bucketID: true,       // PK (필요시)
+                content: true,
+                isCompleted: true,
+                isChallenging: true,
             },
+            orderBy: {
+                createdAt: 'desc',
             },
-            orderBy: { /* 필요하면 정렬, 예: createdAt: 'desc' */ },
         });
     
-        // 유저가 버킷을 하나도 안 갖고 있을 때
-        if (!buckets || buckets.length === 0) {
-            return res.status(200).json({
-            success: true,
-            message: '해당 유저는 버킷이 없습니다.',
-            userID: userID,
-            nickname: '',      // 유저 정보를 아래처럼 별도 조회할 수도 있음
-            buckets: [],
-            });
-        }
-    
-        // 2) 첫 번째 버킷에서 user 정보 추출 (모두 동일 유저이므로)
-        const { user } = buckets[0]; 
-        // user.userID, user.nickname
-    
-        // 3) 응답 데이터 구성
-        //    bucketID, content, isCompleted => buckets 배열
-        const responseData = {
-            userID: user.userID,
-            nickname: user.nickname,
-            buckets: buckets.map(b => ({
-            bucketID: b.bucketID,
-            content: b.content,
-            isCompleted: b.isCompleted,
-            })),
-        };
-    
+        // 2) 응답
         return res.status(200).json({
             success: true,
-            ...responseData,
+            user: userID,
+            count: buckets.length,
+            type: 'REPEAT 반복형',
+            buckets,
         });
         } catch (error) {
-        console.error('유저 버킷리스트 조회 실패:', error);
+        console.error('반복형 버킷 조회 실패:', error);
         return res.status(500).json({
             success: false,
             error: { code: 500, message: '서버 내부 오류가 발생했습니다.' },

--- a/src/routes/momentRoutes.js
+++ b/src/routes/momentRoutes.js
@@ -1,6 +1,6 @@
 import express from 'express';
 import multer from 'multer';
-import { activateBucketChallenge, createBucket, deactivateBucketChallenge, getAllUserBuckets, getBucketDetail, getCompletedBuckets, updateBucket, uploadAchievementPhoto } from '../controllers/bucketControllers.js';
+import { activateBucketChallenge, createBucket, deactivateBucketChallenge, getBucketDetail, getCompletedBuckets, getRepeatBuckets, updateBucket, uploadAchievementPhoto } from '../controllers/bucketControllers.js';
 import { createMoments, getDetailMoment, getMomentsByBucket, updateMoment } from '../controllers/momentControllers.js';
 import { jwtMiddleware } from '../middlewares/jwtMiddlewares.js';
 
@@ -19,7 +19,7 @@ router.patch('/:bucketID/un-challenge', deactivateBucketChallenge); // 혹시 �
 router.get('/completed-count', getCompletedBuckets); // 완료된 버킷리스트 갯수(홈 화면 이용)
 router.get('/:bucketID', getBucketDetail); // 버킷리스트 상세 조회
 router.patch('/:bucketID', updateBucket); // 버킷 이름 수정
-router.get('/all/buckets', getAllUserBuckets); // 전체 버킷 목록
+router.get('/all/repeat', getRepeatBuckets); // 반복형 버킷 목록
 
 //모멘트 등록 조회(bucketID)
 router.post('/moments/:bucketID', createMoments);

--- a/src/routes/momentRoutes.js
+++ b/src/routes/momentRoutes.js
@@ -1,6 +1,6 @@
 import express from 'express';
 import multer from 'multer';
-import { activateBucketChallenge, createBucket, deactivateBucketChallenge, getBucketDetail, getCompletedBuckets, getRepeatBuckets, updateBucket, uploadAchievementPhoto } from '../controllers/bucketControllers.js';
+import { activateBucketChallenge, createBucket, deactivateBucketChallenge, getAchievementBuckets, getBucketDetail, getCompletedBuckets, getRepeatBuckets, updateBucket, uploadAchievementPhoto } from '../controllers/bucketControllers.js';
 import { createMoments, getDetailMoment, getMomentsByBucket, updateMoment } from '../controllers/momentControllers.js';
 import { jwtMiddleware } from '../middlewares/jwtMiddlewares.js';
 
@@ -19,7 +19,8 @@ router.patch('/:bucketID/un-challenge', deactivateBucketChallenge); // 혹시 �
 router.get('/completed-count', getCompletedBuckets); // 완료된 버킷리스트 갯수(홈 화면 이용)
 router.get('/:bucketID', getBucketDetail); // 버킷리스트 상세 조회
 router.patch('/:bucketID', updateBucket); // 버킷 이름 수정
-router.get('/all/repeat', getRepeatBuckets); // 반복형 버킷 목록
+router.get('/all/repeat', getRepeatBuckets); // 반복형 버킷 목록 조회
+router.get('/all/achievement', getAchievementBuckets); // 달성형 버킷 목록 조회
 
 //모멘트 등록 조회(bucketID)
 router.post('/moments/:bucketID', createMoments);


### PR DESCRIPTION
1) 기존 전체 조회 삭제
2) 반복형과 달성형 따로 받아오는 API
3) 반복형 버킷리스트 전체 목록 조회 GET api/bucket/all/repeat
content, isChallenging, isCompleted, bucketID
![image](https://github.com/user-attachments/assets/261460c3-5853-4b56-ae9e-bfbed7b8d3ab)

4) 달성형 버킷리스트 전체 목록 조회 GET api/bucket/all/achievement
content, isCompleted, bucketID
![image](https://github.com/user-attachments/assets/96ff6837-6ee9-4996-a277-44cae9664f7c)


- 로그인이 되어있는 user의 버킷 목록을 조회
- 정렬은 추후 수정 예정