### PR TITLE
모멘트 전체 완료시 도전 리스트에서 제외 (버그 수정) + 모멘트 기능 메인페이지 버킷, 모멘트 조회 기능 구현

### DIFF
--- a/src/controllers/momentControllers.js
+++ b/src/controllers/momentControllers.js
@@ -237,7 +237,7 @@ export const updateMoment = async (req, res) => {
             if (totalMoments > 0 && totalMoments === completedMoments) {
                 updatedBucket = await tx.bucket.update({
                     where: { bucketID },
-                    data: { isCompleted: true, updatedAt: new Date() },
+                    data: { isCompleted: true, isChallenging: false, updatedAt: new Date() },
                 });
             }
 

--- a/src/routes/momentRoutes.js
+++ b/src/routes/momentRoutes.js
@@ -1,7 +1,7 @@
 import express from 'express';
 import multer from 'multer';
 import { activateBucketChallenge, createBucket, deactivateBucketChallenge, deleteBucket, getAchievementBuckets, getBucketDetail, getCompletedBuckets, getRepeatBuckets, updateBucket, uploadAchievementPhoto } from '../controllers/bucketControllers.js';
-import { createMoments, getDetailMoment, getMomentsByBucket, updateMoment } from '../controllers/momentControllers.js';
+import { createMoments, getChallengingBucketsAndMoments, getDetailMoment, getMomentsByBucket, updateMoment } from '../controllers/momentControllers.js';
 import { jwtMiddleware } from '../middlewares/jwtMiddlewares.js';
 
 const router = express.Router();
@@ -29,5 +29,7 @@ router.get('/moments/:bucketID', getMomentsByBucket); // (반복형) 버킷리�
 router.get('/moment/:momentID', getDetailMoment); // 선택한 모멘트의 상세 조회
 router.patch('/moments/:momentID', upload.single('photoUrl'), updateMoment); //모멘트 달성
 
+// 도전중인 버킷과 모멘트 조회(모멘트 메인화면)
+router.get('/challenging/main', getChallengingBucketsAndMoments);
 
 export default router;


### PR DESCRIPTION
1) 모멘트 전체 완료시 도전리스트에서 계속 true로 있는 버그 수정 -> false로 처리
2) 모멘트 메인 페이지의 정보 조회 기능 구현
- moment: photoUrl, content
- bucket: content, momentCount, completedMomentsCount, bucketID
버킷리스트는 isChallenging이 true인 버킷만(도전 중인 버킷)
모멘트는 now가 startDate와 endDate사이인 모멘트만(진행 중인 모멘트)

- count들은 전부 실시간 계산 로직

3) 
![image](https://github.com/user-attachments/assets/c9648e66-b2c4-4e5d-b510-174f7e6f3268)
![image](https://github.com/user-attachments/assets/e1b6b35a-8ab2-4f87-a050-90943e3af4df)

