### PR TITLE
fix - 친구 피드 응원하기 수정

### DIFF
--- a/src/middlewares/jwtMiddlewares.js
+++ b/src/middlewares/jwtMiddlewares.js
@@ -69,7 +69,7 @@ export const jwtMiddleware = async (req, res, next) => {
 
         next(); // 다음 미들웨어로 전달
       } catch (refreshErr) {
-        return res.status(403).json({ message: '새로운 Access Token 발급 실패' });
+        return res.status(401).json({ message: '새로운 Access Token 발급 실패' });
       }
     } else {
       return res.status(401).json({ message: '유효하지 않은 Access Token입니다.' });


### PR DESCRIPTION
기존 피드 응원하기 POST ('/api/friends/cheer/:feedId') 
- feed테이블의 feedID 사용

수정한 피드 응원하기 POST ('/api/friends/cheer/:friendId/:momentId')
- feed 테이블 삭제
- 파라미터로 friendId, momentId 받아옴
- friendFeed 테이블의 feedID 대신 momentID로 변경
- friend테이블에서 친구 관계 확인
- friend관계 확인 후, 해당 친구의 moment인지 확인
- moment가 존재해도 해당 친구사용자 모멘트가 아니면 오류

+ JWT미들웨어 토큰 만료 에러 401로 통일

+ Prisma 수정했으므로, npx prisma db push 필요시 사용

POSTMAN API에서 친구(피드)에서 친구 응원하기로 확인 가능
![image](https://github.com/user-attachments/assets/aa8d92fe-8cc1-4e61-9110-a99c9a550002)

