### PR TITLE
fix - 친구 피드 조회할때 응원여부 포함 & 노크하기 로직 수정

### DIFF
--- a/src/controllers/feedControllers.js
+++ b/src/controllers/feedControllers.js
@@ -45,27 +45,27 @@ export const getFriendFeed = async (req, res) => {
 
     // 3. 친구의 반복형 버킷리스트 가져오기 (type이 REPEAT인 경우만)
     const buckets = await prisma.bucket.findMany({
-        where: {
-          user: { userID: friendID },
-          type: "REPEAT",
-        },
-        select: {
-          bucketID: true,
-          type: true,
-          content: true,
-        },
-      });
+      where: {
+        user: { userID: friendID },
+        type: "REPEAT",
+      },
+      select: {
+        bucketID: true,
+        type: true,
+        content: true,
+      },
+    });
   
-      const repeatBuckets = buckets.filter(
-        (bucket) => bucket.type !== "ACHIEVEMENT"
-      );
+    const repeatBuckets = buckets.filter(
+      (bucket) => bucket.type !== "ACHIEVEMENT"
+    );
 
     // 반복형 버킷리스트가 없을 경우
     if (repeatBuckets.length === 0) {
-    return res.status(404).json({
-        success: false,
-        message: "해당 친구의 반복형 버킷리스트가 존재하지 않습니다.",
-    });
+      return res.status(404).json({
+          success: false,
+          message: "해당 친구의 반복형 버킷리스트가 존재하지 않습니다.",
+      });
     }
 
     // 4. 반복형 버킷리스트의 완료된 모멘트 가져오기
@@ -82,37 +82,49 @@ export const getFriendFeed = async (req, res) => {
           },
         },
         select: {
+          momentID: true,
+          content: true,
           photoUrl: true,
           updatedAt: true,
-          momentID: true,
         },
         orderBy: {
-          updatedAt: "desc", // 최신순 정렬
+          updatedAt: "desc",
         },
       });
 
-      // 모멘트 데이터 추가
-      // `${nickname}님이 ${content} 목표를 유지 중이에요!` 와 같은 형식으로 활용 가능
-      bucketMoments.forEach((moment) => {
+      // ✅ 사용자가 해당 모멘트에 응원했는지 확인
+      for (const moment of bucketMoments) {
+        const friendFeed = await prisma.friendFeed.findFirst({
+          where: {
+            userID,  // 조회하는 사용자
+            momentID: moment.momentID, // 친구의 모멘트
+          },
+          select: {
+            cheer: true, // 응원 여부
+          },
+        });
+
         moments.push({
           momentId: moment.momentID,
-          content: bucket.content,
+          bucketContent: bucket.content,
+          momentContent: moment.content,
           imageUrl: moment.photoUrl,
           date: moment.updatedAt,
+          cheered: friendFeed ? friendFeed.cheer : false, // 사용자가 응원한 경우 true, 없으면 false
         });
+      }
+    }
+
+    // 5. 완료된 모멘트가 없을 경우 (200 응답)
+    if (moments.length === 0) {
+      return res.status(200).json({
+        success: true,
+        message: "7일 이내 완료된 모멘트가 존재하지 않습니다.",
+        moments: [],
       });
     }
 
-    // 완료된 모멘트가 없을 경우
-    if (moments.length === 0) {
-        return res.status(404).json({
-        success: false,
-        message: "7일 이내 완료된 모멘트가 존재하지 않습니다.",
-        });
-    }
-
-
-    // 5. 모멘트 정렬 및 응답 반환
+    // 6. 모멘트 정렬 및 응답 반환
     moments.sort((a, b) => new Date(b.date) - new Date(a.date)); // 최신순 정렬
 
     return res.status(200).json({

--- a/src/controllers/friendControllers.js
+++ b/src/controllers/friendControllers.js
@@ -264,14 +264,16 @@ export const knockFriend = async (req, res) => {
     }
 
     // 친구가 최근 7일 이내에 피드(모멘트)를 올렸는지 확인  -> 내부 확인용
-    const sevenDaysAgo = moment().subtract(7, 'days');
+    const sevenDaysAgo = moment().subtract(7, 'days'); // 현재 날짜 기준 7일 전
 
-    const hasRecentMoment = friendRelation.friendUser.moments.some(momentItem => 
-      momentItem.createdAt && moment(new Date(momentItem.createdAt)).isAfter(sevenDaysAgo)
+    const hasRecentCompletedMoment = friendRelation.friendUser.moments.some(momentItem => 
+      momentItem.isCompleted === true &&
+      momentItem.updatedAt && 
+      moment(new Date(momentItem.updatedAt)).isAfter(sevenDaysAgo)
     );
 
-    if (hasRecentMoment) {
-      return res.status(403).json({ status: "failed", message: "해당 친구는 최근 7일 이내에 피드를 올렸습니다." });
+    if (hasRecentCompletedMoment) {
+      return res.status(403).json({ status: "failed", message: "해당 친구는 최근 7일 이내에 완료한 피드(모멘트)가 있습니다." });
     }
 
     // 주별 노크 제한 검사


### PR DESCRIPTION
1. 친구 피드 조회 => 응원 여부 포함 수정 + 버킷이름, 모멘트 이름 같이 출력되도록 변경 (bucketContent, momentContent, cheered 추가 출력)
![image](https://github.com/user-attachments/assets/771721bf-31d0-43fa-9266-8359e477ed46)

2. 친구 노크하기 로직 수정
- createdAt 기준 X, updateAt 최근 7일 이내에 isCompleted한 피드(모멘트)가 있으면 노크 X
- 간단하게 updatedAt 최근 7일이내올라온 피드(모멘트)가 없는 경우 응원하기 가능