### PR TITLE
fix : 실시간 알림 개수 전달 Long Polling으로 변경 & 일주일 모멘트 완료 현황 조회 수정 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ https/
 .env.development
 .env.production
 seed.js
-prisma.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "date-fns": "^4.1.0",
+        "date-fns-tz": "^3.2.0",
         "dotenv": "^16.4.7",
         "dotenv-flow": "^4.1.0",
         "express": "^4.21.2",
@@ -3295,6 +3296,14 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/date-fns-tz": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-3.2.0.tgz",
+      "integrity": "sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==",
+      "peerDependencies": {
+        "date-fns": "^3.0.0 || ^4.0.0"
       }
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "date-fns": "^4.1.0",
+    "date-fns-tz": "^3.2.0",
     "dotenv": "^16.4.7",
     "dotenv-flow": "^4.1.0",
     "express": "^4.21.2",

--- a/src/controllers/homeControllers.js
+++ b/src/controllers/homeControllers.js
@@ -1,59 +1,84 @@
 import { PrismaClient } from '@prisma/client';
-import { eachDayOfInterval } from "date-fns";
-
 
 const prisma = new PrismaClient();
 
-// 홈 조회
+// 홈 당일 모멘트 조회
 export const getHome = async (req, res) => {
-    try {
-      // 현재 사용자 조회
-      const currentUser = await prisma.user.findUnique({
-        where: { userID: req.user.userID },
-      });
-
-      if (!currentUser) { 
-        return res.status(404).json({ 
-          success: false,
-          error: { code: 404, message: '현재 사용자를 찾을 수 없습니다.' }
-        });
-      }
-      
-      // 사용자의 moments 조회 
-      const moments = await prisma.moment.findMany({
-        where: { userID: req.user.userID },
-        orderBy: { date: 'desc' },
-        select: {
-          momentID: true,
-          title: true, 
-          description: true,
-          status: true,
-          date: true
-        }
-      });
-
-      return res.status(200).json({
-        success: true,
-        messages: "성공적으로 조회 완료하였습니다.",
-        user: currentUser.userID,
-        moments: moments
-
-      })
-    } catch (err) {
-      console.error('홈 조회 실패:', err.message);
-      res.status(500).json({ 
-        success: false,
-        error: { code: 500, message: '홈 조회를 하는 데 실패하였습니다.' }
-      });
-    }
-  };
-
-// 일주일 모멘트 완료 여부 확인 
-export const getCompletedMomentsByWeek = async (req, res) => {
   try {
+    // 현재 인증된 사용자 정보 가져오기
+    const userID = req.user.userID; // 현재 사용자 ID
+    const dateString = req.params.date;
+
     // 현재 사용자 조회
     const currentUser = await prisma.user.findUnique({
-      where: { userID: req.user.userID },
+      where: { userID },
+    });
+
+    if (!currentUser) { 
+      return res.status(404).json({ 
+        success: false,
+        error: { code: 404, message: '현재 사용자를 찾을 수 없습니다.' }
+      });
+    };
+    
+    const date = new Date(dateString); // 문자열 날짜 => Date 객체
+    if (isNaN(date.getTime())) {
+      return res.status(400).json({
+        success: false,
+        error: { code: 400, message: "유효하지 않은 날짜 형식입니다." },
+      });
+    }
+
+    // 사용자의 moments 조회 
+    const moments = await prisma.moment.findMany({
+      where: {
+        userID,
+        startDate: { lte: date }, 
+        endDate: { gte: date }      
+      },
+      select: {
+        momentID: true,
+        content: true, 
+        isCompleted: true
+      }
+    });
+
+    // 당일 모먼트 완료 개수 
+    const completedCount = await prisma.moment.count({
+      where: {
+        userID,
+        startDate: { lte: date }, 
+        endDate: { gte: date },
+        isCompleted: true
+      }
+    });
+
+    return res.status(200).json({
+      success: true,
+      messages: "성공적으로 조회 완료하였습니다.",
+      user: currentUser.userID,
+      moments: moments,
+      completedCount: completedCount
+
+    })
+  } catch (err) {
+    console.error('홈 조회 실패:', err.message);
+    res.status(500).json({ 
+      success: false,
+      error: { code: 500, message: '홈 조회를 하는 데 실패하였습니다.' }
+    });
+  }
+};
+
+// 일주일 완료 상태 조회 
+export const getCompletedMomentsByWeek = async (req, res) => {
+  try {
+    const userID = req.user.userID; // 인증된 사용자 ID
+    const dateString = req.params.date;  
+
+    // 현재 사용자 조회
+    const currentUser = await prisma.user.findUnique({
+      where: { userID },
     });
 
     if (!currentUser) { 
@@ -138,38 +163,66 @@ export const getCompletedMomentsByWeek = async (req, res) => {
   }
 };
 
-// 연속적으로 인증한 날짜 조회 (작심 N일일)
+// 연속적으로 인증한 날짜 조회 (작심 N일)
 export const getConsecutiveCompletedDays = async (req, res) => {
   try {
-    const { date } = req.body;
+    const userID = req.user.userID; // 인증된 사용자 ID
+    const dateString = req.params.date;     
 
-    if (!date) {
+    // 현재 사용자 조회
+    const currentUser = await prisma.user.findUnique({
+      where: { userID }
+    });
+
+    if (!currentUser) {
+      return res.status(404).json({
+        success: false,
+        error: { code: 404, message: '현재 사용자를 찾을 수 없습니다.' }
+      });
+    }
+    
+    const targetDate = new Date(dateString);
+    if (isNaN(targetDate.getTime())) {
       return res.status(400).json({
         success: false,
-        error: { code: 400, message: "날짜(date)는 필수 입력값입니다." }
+        error: { code: 400, message: "유효하지 않은 날짜 형식입니다." },
       });
     }
 
-    // 특정 주에서 데이터 조회
-    const completedMoments = await prisma.moment.findMany({
-      where: {
-        userID: userID, // 현재 사용자만 조회
-        date: date
-      },
-      select: {
-        date: true,
-        complete: true,
+    // 연속된 isCompleted === true인 날짜 개수를 계산
+    let consecutiveDays = 1;
+    let checkDate = new Date(targetDate);
+    checkDate.setDate(checkDate.getDate() - 1); // 하루 전부터 검사 시작
+
+    while (true) {
+      const moments = await prisma.moment.findMany({
+        where: {
+          userID: userID,
+          startDate: { lte: checkDate },
+          endDate: { gte: checkDate }
+        },
+        select: {
+          isCompleted: true,
+        }
+      });
+
+      const isComplete = moments.length > 0 && moments.some(m => m.isCompleted);
+
+      if (isComplete) {
+        consecutiveDays++;
+        checkDate.setDate(checkDate.getDate() - 1);
+      } else {
+        break;
       }
-    });
+    }
 
     return res.status(200).json({
       success: true,
-      messages: "해당 날짜의 완료된 데이터를 성공적으로 조회하였습니다.",
-      completedMoments: completedMoments
+      message: "연속 완료된 날짜 개수를 성공적으로 조회하였습니다.",
+      consecutiveDays: consecutiveDays
     });
-
   } catch (err) {
-    console.error("당일 완료 데이터 조회 실패:", err.message);
+    console.error("연속 완료 날짜 조회 실패:", err.message);
     return res.status(500).json({
       success: false,
       error: { code: 500, message: "서버 내부 오류가 발생했습니다." }
@@ -177,7 +230,35 @@ export const getConsecutiveCompletedDays = async (req, res) => {
   }
 };
 
-// 버킷리스트 달성 현황 
+export const getCompletedBucket = async (req, res) => {
+  try {
+    const userID = req.user.userID; // JWT 인증 후 주입된 userID
+
+    // 전체 버킷 수
+    const totalBuckets = await prisma.bucket.count({
+        where: { userID },
+    });
+    
+        // 완료된 버킷 수
+    const completedBucketsCount = await prisma.bucket.count({
+        where: { userID, isCompleted: true },
+    });
+
+    const completionRate = totalBuckets === 0
+      ? 0
+      : (completedBucketsCount / totalBuckets) * 100;
 
 
-module.exports = { getHome, getNotifications, markNotificationAsRead, getCompletedMomentsByWeek, getCompletedMomentsByDay};
+    return res.status(200).json({
+      success: true,
+      completedBucketsCount: completedBucketsCount,
+      completionRate: completionRate.toFixed(2),
+    });
+  } catch (error) {
+    console.error('버킷 달성 현황 조회 실패:', error);
+    return res.status(500).json({
+      success: false,
+      error: { code: 500, message: '서버 내부 오류가 발생했습니다.' },
+    });
+  }
+};

--- a/src/controllers/homeControllers.js
+++ b/src/controllers/homeControllers.js
@@ -47,7 +47,8 @@ export const getHome = async (req, res) => {
       });
     }
   };
-  
+
+// 일주일 모멘트 완료 여부 확인 
 export const getCompletedMomentsByWeek = async (req, res) => {
   try {
     // 현재 사용자 조회

--- a/src/routes/homeRoutes.js
+++ b/src/routes/homeRoutes.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import { getCompletedMomentsByWeek, getConsecutiveCompletedDays, getHome } from '../controllers/homeControllers.js';
+import { getCompletedBucket, getCompletedMomentsByWeek, getConsecutiveCompletedDays, getHome } from '../controllers/homeControllers.js';
 import { jwtMiddleware } from '../middlewares/jwtMiddlewares.js';
 import { deleteNotification, getAndMarkNotificationsAsRead, longPollingNotifications } from '../controllers/notificationController.js';
 
@@ -15,5 +15,7 @@ router.get('/momentsComplete/week/:date', getCompletedMomentsByWeek);         //
 router.patch('/notifications', getAndMarkNotificationsAsRead);          // 알림 조회 및 읽음 처리 
 router.get('/notifications/unreadCount', longPollingNotifications); 
 router.delete('/notifications/:notificationID', deleteNotification);    // 알림 삭제 
+
+router.get('/', getCompletedBucket);                                    // 버킷리스트 달성 현황 조회 
 
 export default router;

--- a/src/routes/homeRoutes.js
+++ b/src/routes/homeRoutes.js
@@ -1,7 +1,7 @@
 import express from 'express';
 import { getCompletedMomentsByWeek, getConsecutiveCompletedDays, getHome } from '../controllers/homeControllers.js';
 import { jwtMiddleware } from '../middlewares/jwtMiddlewares.js';
-import { deleteNotification, getAndMarkNotificationsAsRead } from '../controllers/notificationController.js';
+import { deleteNotification, getAndMarkNotificationsAsRead, longPollingNotifications } from '../controllers/notificationController.js';
 
 const router = express.Router();
 
@@ -9,10 +9,11 @@ const router = express.Router();
 router.use(jwtMiddleware);
 
 router.get('/:date', getHome);                                                // 홈 당일 모먼트 조회
-router.get('/consecutiveDays/:date',getConsecutiveCompletedDays);             // 연속적으로 인증한 날짜 조회 
+router.get('/consecutiveDays/:date',getConsecutiveCompletedDays);             // 연속적으로 인증한 날짜 조회 (작심 N일일)
 router.get('/momentsComplete/week/:date', getCompletedMomentsByWeek);         // 일주일 인증 확인 
 
-router.patch('/notifications', getAndMarkNotificationsAsRead);          // 알림 조회 및 읽음 처리  
+router.patch('/notifications', getAndMarkNotificationsAsRead);          // 알림 조회 및 읽음 처리 
+router.get('/notifications/unreadCount', longPollingNotifications); 
 router.delete('/notifications/:notificationID', deleteNotification);    // 알림 삭제 
 
 export default router;

--- a/src/server.js
+++ b/src/server.js
@@ -1,54 +1,10 @@
 import http from 'http';
-import WebSocket, { WebSocketServer } from 'ws';
-import url from 'url';
 import app from './app.js';
 import { checkS3Connection } from './config/s3config.js';
-import { sendUnreadNotificationsCount } from './controllers/notificationController.js';
 
 const PORT = process.env.PORT || 3000;
 const ENV = process.env.NODE_ENV || 'development';
 const server = http.createServer(app);
-
-// WebSocket 서버 추가
-const wss = new WebSocketServer({ server });
-const connectedUserIDs = new Set();        // userID 저장 
-
-wss.on('connection', (ws, req) => {
-    const params = url.parse(req.url, true).query;
-    const userID = params.userID;
-
-    if (!userID) {
-        ws.send(JSON.stringify({ error: 'userID is required' }));
-        ws.close();
-        return;
-    }
-
-    console.log(`New WebSocket client connected with userID: ${userID}`);
-
-    // 연결된 사용자 저장
-    connectedUserIDs.add(userID);
-
-    // 클라이언트 연결 시 초기 알림 개수 전송 
-    sendUnreadNotificationsCount(userID, wss);
-
-    ws.on('message', (message) => {
-        console.log(`Received message: ${message}`);
-
-        // 클라이언트에 응답 보내기
-        ws.send(`Echo: ${message}`);
-    });
-
-    ws.on('close', () => {
-        console.log('WebSocket client disconnected');
-    });
-});
-
-// 모든 연결된 사용자에 대해 주기적으로 알림 개수 전송
-setInterval(() => {
-    connectedUserIDs.forEach(async (userID) => {
-        await sendUnreadNotificationsCount(userID, wss);
-    });
-}, 10000);
 
 server.listen(PORT, async () => {
     console.log(`Server running on http://localhost:${PORT}`);


### PR DESCRIPTION
1. Long Polling 변경
    - Web Socket API 연동 실패 => Long Polling 방식으로 수정 
    - 30초마다 클라이언트 측에서 요청 
    - 30초 동안 새로운 알림이 생성 되면 알림 개수 갱신 / 변동 없으면 그대로 보낸다. 
2. 일주일 모멘트 완료 현황 조회 수정 
    - 문제점
       a. new Date는 날짜만 입력 받았을 때 UTC 시간대로 인식하여 처리
       b. startOfWeek와 endOfWeek 방식을 사용하면 UTC 시간으로 처리하고 로컬 시간대로 반영하여 날짜가 밀리는 문제 발생 
    - 해결방안
       날짜를 입력 받으면 해당 주의 월요일과 일요일을 일일이 구하자 ! ( getDay()를 활용하여 계산 하는 방식 사용) 